### PR TITLE
Update p3a_linear_algebra.hpp

### DIFF
--- a/p3a_linear_algebra.hpp
+++ b/p3a_linear_algebra.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include "p3a_reduce.hpp"
 
 namespace p3a {


### PR DESCRIPTION
Failed to compile with the following error:

```console
p3a_linear_algebra.hpp:48:32: error: 'function' in namespace 'std' does not name a template type
```

adding `<functional>` header led to successful compile.