### PR TITLE
Cjobrie mandeltensor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,10 @@ set(P3A_HEADERS
   p3a_svd.hpp
   p3a_lie.hpp
   p3a_opts.hpp
+  p3a_mandel6x1.hpp
+  p3a_mandel6x6.hpp
+  p3a_mandel3x6.hpp
+  p3a_mandel6x3.hpp
   )
 
 set(P3A_SOURCES

--- a/gtest-main.C
+++ b/gtest-main.C
@@ -1,0 +1,10 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv) {
+
+  testing::InitGoogleTest(&argc, argv);
+
+  int a = RUN_ALL_TESTS();
+
+  return a;
+}

--- a/p3a_functions.hpp
+++ b/p3a_functions.hpp
@@ -9,8 +9,10 @@ namespace p3a {
 
 template <class T>
 P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-bool compare(T a, T b){
+bool compare(T a, T b)
+{
    return std::abs(a-b) <= epsilon_value<T>();
+}
 
 template <class T>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr

--- a/p3a_functions.hpp
+++ b/p3a_functions.hpp
@@ -11,7 +11,7 @@ template <class T>
 P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 bool compare(T a, T b)
 {
-   return std::abs(a-b) <= epsilon_value<T>();
+   return std::abs(a-b) <= T(2.0)*epsilon_value<T>();
 }
 
 template <class T>

--- a/p3a_functions.hpp
+++ b/p3a_functions.hpp
@@ -8,6 +8,11 @@
 namespace p3a {
 
 template <class T>
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+bool compare(T a, T b){
+   return std::abs(a-b) <= epsilon_value<T>();
+
+template <class T>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 auto square(T const& a)
 {

--- a/p3a_mandel3x6.hpp
+++ b/p3a_mandel3x6.hpp
@@ -26,28 +26,22 @@ namespace p3a {
 /******************************************************************/
 /******************************************************************/
 template <class T>
-class Mandel3x6
+class mandel3x6
 /** 
  * Represents a 3rd order tensor as a 3x6 Mandel array
  */
 /******************************************************************/
 {
- T x11,x12,x13,x14,x15,x16,
-   x21,x22,x23,x24,x25,x26,
-   x31,x32,x33,x34,x35,x36;
+ T m_x11,m_x12,m_x13,m_x14,m_x15,m_x16,
+   m_x21,m_x22,m_x23,m_x24,m_x25,m_x26,
+   m_x31,m_x32,m_x33,m_x34,m_x35,m_x36;
  bool applyTransform;
 
- template<class T>
- P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static
- T r2() {std::sqrt(T(2.0));}
+ static const T r2 = square_root(T(2.0));
 
- template<class T>
- P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static
- T r2i() {T(1.0)/std::sqrt(T(2.0));}
+ static const T r2i = T(1.0)/square_root(T(2.0));
 
- template<class T>
- P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static 
- T two() {T(2.0);}
+ static const T two  = T(2.0);
 
  public:
   /**** constructors, destructors, and assigns ****/
@@ -59,13 +53,12 @@ class Mandel3x6
       T const& X11, T const& X12, T const& X13, T const& X14, T const& X15, T const& X16,
       T const& X21, T const& X22, T const& X23, T const& X24, T const& X25, T const& X26,
       T const& X31, T const& X32, T const& X33, T const& X34, T const& X35, T const& X36):
-      x11(X11),x12(X12),x13(X13),x14(X14),x15(X15),x16(X16),
-      x21(X21),x22(X22),x23(X23),x24(X24),x25(X25),x26(X26),
-      x31(X31),x32(X32),x33(X33),x34(X34),x35(X35),x36(X36),
+      m_x11(X11),m_x12(X12),m_x13(X13),m_x14(X14),m_x15(X15),m_x16(X16),
+      m_x21(X21),m_x22(X22),m_x23(X23),m_x24(X24),m_x25(X25),m_x26(X26),
+      m_x31(X31),m_x32(X32),m_x33(X33),m_x34(X34),m_x35(X35),m_x36(X36),
       applyTransform(true)
   {
-    if (applyTransform)
-        this->MandelXform();
+    this->MandelXform();
   }
 
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
@@ -74,9 +67,9 @@ class Mandel3x6
     T const& X21, T const& X22, T const& X23, T const& X24, T const& X25, T const& X26,
     T const& X31, T const& X32, T const& X33, T const& X34, T const& X35, T const& X36,
     bool const& Xform):
-    x11(X11),x12(X12),x13(X13),x14(X14),x15(X15),x16(X16),
-    x21(X21),x22(X22),x23(X23),x24(X24),x25(X25),x26(X26),
-    x31(X31),x32(X32),x33(X33),x34(X34),x35(X35),x36(X36),
+    m_x11(X11),m_x12(X12),m_x13(X13),m_x14(X14),m_x15(X15),m_x16(X16),
+    m_x21(X21),m_x22(X22),m_x23(X23),m_x24(X24),m_x25(X25),m_x26(X26),
+    m_x31(X31),m_x32(X32),m_x33(X33),m_x34(X34),m_x35(X35),m_x36(X36),
     applyTransform(Xform)
   {
     if (applyTransform)
@@ -86,9 +79,9 @@ class Mandel3x6
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   mandel3x6(
       static_matrix<T,3,6> const& X, bool const& Xform):
-    x11(X(0,0)),x12(X(0,1)),x13(X(0,2)),x14(X(0,3)),x15(X(0,4)),x16(X(0,5)),
-    x21(X(1,0)),x22(X(1,1)),x23(X(1,2)),x24(X(1,3)),x25(X(1,4)),x26(X(1,5)),
-    x31(X(2,0)),x32(X(2,1)),x33(X(2,2)),x34(X(2,3)),x35(X(2,4)),x36(X(2,5)),
+    m_x11(X(0,0)),m_x12(X(0,1)),m_x13(X(0,2)),m_x14(X(0,3)),m_x15(X(0,4)),m_x16(X(0,5)),
+    m_x21(X(1,0)),m_x22(X(1,1)),m_x23(X(1,2)),m_x24(X(1,3)),m_x25(X(1,4)),m_x26(X(1,5)),
+    m_x31(X(2,0)),m_x32(X(2,1)),m_x33(X(2,2)),m_x34(X(2,3)),m_x35(X(2,4)),m_x36(X(2,5)),
     applyTransform(Xform)
   {
     if (applyTransform)
@@ -98,9 +91,9 @@ class Mandel3x6
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   mandel3x6(
       static_matrix<T,3,6> const& X):
-    x11(X(0,0)),x12(X(0,1)),x13(X(0,2)),x14(X(0,3)),x15(X(0,4)),x16(X(0,5)),
-    x21(X(1,0)),x22(X(1,1)),x23(X(1,2)),x24(X(1,3)),x25(X(1,4)),x26(X(1,5)),
-    x31(X(2,0)),x32(X(2,1)),x33(X(2,2)),x34(X(2,3)),x35(X(2,4)),x36(X(2,5)),
+    m_x11(X(0,0)),m_x12(X(0,1)),m_x13(X(0,2)),m_x14(X(0,3)),m_x15(X(0,4)),m_x16(X(0,5)),
+    m_x21(X(1,0)),m_x22(X(1,1)),m_x23(X(1,2)),m_x24(X(1,3)),m_x25(X(1,4)),m_x26(X(1,5)),
+    m_x31(X(2,0)),m_x32(X(2,1)),m_x33(X(2,2)),m_x34(X(2,3)),m_x35(X(2,4)),m_x36(X(2,5)),
     applyTransform(true)
   {
     this->MandelXform();
@@ -108,81 +101,80 @@ class Mandel3x6
 
   //return by mandel index 1-6
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x11() const { return x11; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x12() const { return x12; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x13() const { return x13; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x14() const { return x14; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x15() const { return x15; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x16() const { return x16; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x21() const { return x21; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x22() const { return x22; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x23() const { return x23; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x24() const { return x24; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x25() const { return x25; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x26() const { return x26; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x31() const { return x31; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x32() const { return x32; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x33() const { return x33; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x34() const { return x34; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x35() const { return x35; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x36() const { return x36; }
+  T const& x11() const { return m_x11; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x12() const { return m_x12; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x13() const { return m_x13; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x14() const { return m_x14; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x15() const { return m_x15; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x16() const { return m_x16; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x21() const { return m_x21; }
+  [[nodisca]] P3A_HOST P3A_DEVICrdE P3A_ALWAYS_INLINE constexpr
+  T const& x22() const { return m_x22; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x23() const { return m_x23; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x24() const { return m_x24; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x25() const { return m_x25; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x26() const { return m_x26; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x31() const { return m_x31; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x32() const { return m_x32; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x33() const { return m_x33; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x34() const { return m_x34; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x35() const { return m_x35; }
+  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x36() const { return m_x36; }
 
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x11() { return x11; }
+  T& x11() { return m_x11; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x12() { return x12; }
+  T& x12() { return m_x12; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x13() { return x13; }
+  T& x13() { return m_x13; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x14() { return x14; }
+  T& x14() { return m_x14; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x15() { return x15; }
+  T& x15() { return m_x15; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x16() { return x16; }
+  T& x16() { return m_x16; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x21() { return x21; }
+  T& x21() { return m_x21; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x22() { return x22; }
+  T& x22() { return m_x22; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x23() { return x23; }
+  T& x23() { return m_x23; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x24() { return x24; }
+  T& x24() { return m_x24; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x25() { return x25; }
+  T& x25() { return m_x25; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x26() { return x26; }
+  T& x26() { return m_x26; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x31() { return x31; }
+  T& x31() { return m_x31; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x32() { return x32; }
+  T& x32() { return m_x32; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x33() { return x33; }
+  T& x33() { return m_x33; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x34() { return x34; }
+  T& x34() { return m_x34; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x35() { return x35; }
+  T& x35() { return m_x35; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x36() { return x36; }
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x36() { return m_x36; }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
   mandel3x6<T> zero()
   {
     return mandel3x6<T>(
@@ -192,7 +184,7 @@ class Mandel3x6
         false);
   }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
   mandel6x6<T> identity()
   {
     return mandel3x6<T>(
@@ -202,20 +194,20 @@ class Mandel3x6
         true);
   }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   void MandelXform()
   {
-        x14*=r2i, x15*=r2i, x16*=r2i, 
-        x24*=r2i, x25*=r2i, x26*=r2i,
-        x34*=r2i, x35*=r2i, x36*=r2i;
+        m_x14*=r2i, m_x15*=r2i, m_x16*=r2i, 
+        m_x24*=r2i, m_x25*=r2i, m_x26*=r2i,
+        m_x34*=r2i, m_x35*=r2i, m_x36*=r2i;
   }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   void invMandelXform()
   {
-        x14/=r2i, x15/=r2i, x16/=r2i, 
-        x24/=r2i, x25/=r2i, x26/=r2i,
-        x34/=r2i, x35/=r2i, x36/=r2i;
+        m_x14/=r2i, m_x15/=r2i, m_x16/=r2i, 
+        m_x24/=r2i, m_x25/=r2i, m_x26/=r2i,
+        m_x34/=r2i, m_x35/=r2i, m_x36/=r2i;
   }
 
 };
@@ -232,7 +224,7 @@ operator*(
         mandel3x6<A> const& a, 
         B const& c)
 {
-    return mandel3x6<decltype(a.x11()*c)>(
+    return mandel3x6<decltype(A()*B())>(
             a.x11()*c, a.x12()*c, a.x13()*c, a.x14()*c, a.x15()*c, a.x16()*c,
             a.x21()*c, a.x22()*c, a.x23()*c, a.x24()*c, a.x25()*c, a.x26()*c,
             a.x31()*c, a.x32()*c, a.x33()*c, a.x34()*c, a.x35()*c, a.x36()*c,
@@ -258,7 +250,7 @@ operator/(
         mandel3x6<A> const& a, 
         B const& c)
 {
-    return mandel6x6<decltype<(a.x11() / c)>(
+    return mandel6x6<decltype(A()*B())>(
             a.x11()/c, a.x12()/c, a.x13()/c, a.x14()/c, a.x15()/c, a.x16()/c,
             a.x21()/c, a.x22()/c, a.x23()/c, a.x24()/c, a.x25()/c, a.x26()/c,
             a.x31()/c, a.x32()/c, a.x33()/c, a.x34()/c, a.x35()/c, a.x36()/c,
@@ -267,7 +259,7 @@ operator/(
 
 //division /= by constant
 template <class A>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator/=(
         mandel3x6<A>& a, 
         A const& c)
@@ -294,7 +286,7 @@ void operator/=(
 
 //multiplication *= by constant
 template <class A>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator*=(
         mandel3x6<A>& a, 
         A const& c)
@@ -321,7 +313,7 @@ void operator*=(
 
 //mandel3x6 += addition
 template <class T>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator+=(
     mandel3x6<T>& a, 
     mandel3x6<T> const& b)
@@ -348,7 +340,7 @@ void operator+=(
 
 //mandel3x6 -= subtraction
 template <class T>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator-=(
     mandel3x6<T>& a, 
     mandel3x6<T> const& b)
@@ -436,36 +428,7 @@ auto operator*(
     return vector3<decltype(C.x11()*v.x1())>(
         (C.x11()*v.x1() + C.x12()*v.x2() + C.x13()*v.x3() + C.x14()*v.x4() + C.x15()*v.x5() + C.x16()*v.x6()),
         (C.x21()*v.x1() + C.x22()*v.x2() + C.x23()*v.x3() + C.x24()*v.x4() + C.x25()*v.x5() + C.x26()*v.x6()),
-        (C.x31()*v.x1() + C.x32()*v.x2() + C.x33()*v.x3() + C.x34()*v.x4() + C.x35()*v.x5() + C.x36()*v.x6()))
-}
-
-/** Tensor multiply mandel3x6 (3x6) by mandel6x6 (6x6) **/
-template <class T, class U>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-auto operator*(
-    mandel3x6<T> const &e,
-    mandel6x6<U> const &k)
-{
-    return mandel3x6<decltype(e.x11()*k.x11())>(
-            e.x11()*k.x11() + e.x12()*k.x21() + e.x13()*k.x31() + e.x14()*k.x41() + e.x15()*k.x51() + e.x16()*k.x61(),
-            e.x11()*k.x12() + e.x12()*k.x22() + e.x13()*k.x32() + e.x14()*k.x42() + e.x15()*k.x52() + e.x16()*k.x62(),
-            e.x11()*k.x13() + e.x12()*k.x23() + e.x13()*k.x33() + e.x14()*k.x43() + e.x15()*k.x53() + e.x16()*k.x63(),
-            e.x11()*k.x14() + e.x12()*k.x24() + e.x13()*k.x34() + e.x14()*k.x44() + e.x15()*k.x54() + e.x16()*k.x64(),
-            e.x11()*k.x15() + e.x12()*k.x25() + e.x13()*k.x35() + e.x14()*k.x45() + e.x15()*k.x55() + e.x16()*k.x65(),
-            e.x11()*k.x16() + e.x12()*k.x26() + e.x13()*k.x36() + e.x14()*k.x46() + e.x15()*k.x56() + e.x16()*k.x66(),
-            e.x21()*k.x11() + e.x22()*k.x21() + e.x23()*k.x31() + e.x24()*k.x41() + e.x25()*k.x51() + e.x26()*k.x61(),
-            e.x21()*k.x12() + e.x22()*k.x22() + e.x23()*k.x32() + e.x24()*k.x42() + e.x25()*k.x52() + e.x26()*k.x62(),
-            e.x21()*k.x13() + e.x22()*k.x23() + e.x23()*k.x33() + e.x24()*k.x43() + e.x25()*k.x53() + e.x26()*k.x63(),
-            e.x21()*k.x14() + e.x22()*k.x24() + e.x23()*k.x34() + e.x24()*k.x44() + e.x25()*k.x54() + e.x26()*k.x64(),
-            e.x21()*k.x15() + e.x22()*k.x25() + e.x23()*k.x35() + e.x24()*k.x45() + e.x25()*k.x55() + e.x26()*k.x65(),
-            e.x21()*k.x16() + e.x22()*k.x26() + e.x23()*k.x36() + e.x24()*k.x46() + e.x25()*k.x56() + e.x26()*k.x66(),
-            e.x31()*k.x11() + e.x32()*k.x21() + e.x33()*k.x31() + e.x34()*k.x41() + e.x35()*k.x51() + e.x36()*k.x61(),
-            e.x31()*k.x12() + e.x32()*k.x22() + e.x33()*k.x32() + e.x34()*k.x42() + e.x35()*k.x52() + e.x36()*k.x62(),
-            e.x31()*k.x13() + e.x32()*k.x23() + e.x33()*k.x33() + e.x34()*k.x43() + e.x35()*k.x53() + e.x36()*k.x63(),
-            e.x31()*k.x14() + e.x32()*k.x24() + e.x33()*k.x34() + e.x34()*k.x44() + e.x35()*k.x54() + e.x36()*k.x64(),
-            e.x31()*k.x15() + e.x32()*k.x25() + e.x33()*k.x35() + e.x34()*k.x45() + e.x35()*k.x55() + e.x36()*k.x65(),
-            e.x31()*k.x16() + e.x32()*k.x26() + e.x33()*k.x36() + e.x34()*k.x46() + e.x35()*k.x56() + e.x36()*k.x66(),
-            false);//already transformed
+        (C.x31()*v.x1() + C.x32()*v.x2() + C.x33()*v.x3() + C.x34()*v.x4() + C.x35()*v.x5() + C.x36()*v.x6()));
 }
 
 /** Tensor multiply mandel3x6 (3x6) by mandel6x6 (6x6) **/
@@ -501,10 +464,10 @@ auto operator*(
 template <class T, class U>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 auto operator*(
-    symmetric3x3<U> const &s)
+    symmetric3x3<U> const &s,
     mandel3x6<T> const &C, 
 {
-    v = mandel6x1<T>(s);
+    mandel6x1<T> v(s);
     return C*v;
 }
 

--- a/p3a_mandel3x6.hpp
+++ b/p3a_mandel3x6.hpp
@@ -12,6 +12,12 @@
  *
  * - `mandel3x6` (3x6) 3rd order Tensor
  *
+ *   Constructors:
+ *   
+ *   - `mandel3x6(mandel3x6)`
+ *   - `mandel3x6(<list of values>)`
+ *   - `mandel3x6(static_matrix<3,6>)` -- includes testing for symmetry
+ *
  * See additional notes in `p3a_mandel6x1.hpp`.
  */
 
@@ -31,9 +37,17 @@ class Mandel3x6
    x31,x32,x33,x34,x35,x36;
  bool applyTransform;
 
- const T r2 = std::sqrt(T(2.0));
- const T r2i = T(1.0)/std::sqrt(T(2.0));
- const T two = T(2.0);
+ template<class T>
+ P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static
+ T r2() {std::sqrt(T(2.0));}
+
+ template<class T>
+ P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static
+ T r2i() {T(1.0)/std::sqrt(T(2.0));}
+
+ template<class T>
+ P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static 
+ T two() {T(2.0);}
 
  public:
   /**** constructors, destructors, and assigns ****/
@@ -67,6 +81,29 @@ class Mandel3x6
   {
     if (applyTransform)
         this->MandelXform();
+  }
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel3x6(
+      static_matrix<T,3,6> const& X, bool const& Xform):
+    x11(X(0,0)),x12(X(0,1)),x13(X(0,2)),x14(X(0,3)),x15(X(0,4)),x16(X(0,5)),
+    x21(X(1,0)),x22(X(1,1)),x23(X(1,2)),x24(X(1,3)),x25(X(1,4)),x26(X(1,5)),
+    x31(X(2,0)),x32(X(2,1)),x33(X(2,2)),x34(X(2,3)),x35(X(2,4)),x36(X(2,5)),
+    applyTransform(Xform)
+  {
+    if (applyTransform)
+        this->MandelXform();
+  }
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel3x6(
+      static_matrix<T,3,6> const& X):
+    x11(X(0,0)),x12(X(0,1)),x13(X(0,2)),x14(X(0,3)),x15(X(0,4)),x16(X(0,5)),
+    x21(X(1,0)),x22(X(1,1)),x23(X(1,2)),x24(X(1,3)),x25(X(1,4)),x26(X(1,5)),
+    x31(X(2,0)),x32(X(2,1)),x33(X(2,2)),x34(X(2,3)),x35(X(2,4)),x36(X(2,5)),
+    applyTransform(true)
+  {
+    this->MandelXform();
   }
 
   //return by mandel index 1-6
@@ -528,7 +565,5 @@ auto operator*(diagonal3x3<T> const &tt, mandel6x1<U> const &vv)
           false);
 }
 
-
 //misc
 inline int constexpr mandel3x6_component_count = 18;
-

--- a/p3a_mandel3x6.hpp
+++ b/p3a_mandel3x6.hpp
@@ -37,13 +37,14 @@ class mandel3x6
    m_x31,m_x32,m_x33,m_x34,m_x35,m_x36;
  bool applyTransform;
 
- static const T r2 = square_root(T(2.0));
-
- static const T r2i = T(1.0)/square_root(T(2.0));
-
- static const T two  = T(2.0);
-
  public:
+
+  static constexpr T r2 = std::sqrt(T(2.0));
+
+  static constexpr T r2i = T(1.0)/std::sqrt(T(2.0));
+
+  static constexpr T two  = T(2.0);
+
   /**** constructors, destructors, and assigns ****/
   P3A_ALWAYS_INLINE constexpr
   mandel3x6() = default;
@@ -102,39 +103,39 @@ class mandel3x6
   //return by mandel index 1-6
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x11() const { return m_x11; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x12() const { return m_x12; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x13() const { return m_x13; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x14() const { return m_x14; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x15() const { return m_x15; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x16() const { return m_x16; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x21() const { return m_x21; }
-  [[nodisca]] P3A_HOST P3A_DEVICrdE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x22() const { return m_x22; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x23() const { return m_x23; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x24() const { return m_x24; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x25() const { return m_x25; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x26() const { return m_x26; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x31() const { return m_x31; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x32() const { return m_x32; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x33() const { return m_x33; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x34() const { return m_x34; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x35() const { return m_x35; }
-  [[nodisca]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   T const& x36() const { return m_x36; }
 
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
@@ -250,7 +251,7 @@ operator/(
         mandel3x6<A> const& a, 
         B const& c)
 {
-    return mandel6x6<decltype(A()*B())>(
+    return mandel3x6<decltype(A()*B())>(
             a.x11()/c, a.x12()/c, a.x13()/c, a.x14()/c, a.x15()/c, a.x16()/c,
             a.x21()/c, a.x22()/c, a.x23()/c, a.x24()/c, a.x25()/c, a.x26()/c,
             a.x31()/c, a.x32()/c, a.x33()/c, a.x34()/c, a.x35()/c, a.x36()/c,
@@ -464,69 +465,92 @@ auto operator*(
 template <class T, class U>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 auto operator*(
-    symmetric3x3<U> const &s,
-    mandel3x6<T> const &C, 
+    symmetric3x3<T> const &k,
+    mandel3x6<U> const &e)
 {
-    mandel6x1<T> v(s);
-    return C*v;
+    return mandel3x6<decltype(k.xx()*e.x11())>(
+            k.xx()*e.x11() + k.xy()*e.x21() + k.xz()*e.x31(),
+            k.xx()*e.x12() + k.xy()*e.x22() + k.xz()*e.x32(),
+            k.xx()*e.x13() + k.xy()*e.x23() + k.xz()*e.x33(),
+            k.xx()*e.x14() + k.xy()*e.x24() + k.xz()*e.x34(),
+            k.xx()*e.x15() + k.xy()*e.x25() + k.xz()*e.x35(),
+            k.xx()*e.x16() + k.xy()*e.x26() + k.xz()*e.x36(),
+            k.xy()*e.x11() + k.yy()*e.x21() + k.yz()*e.x31(),
+            k.xy()*e.x12() + k.yy()*e.x22() + k.yz()*e.x32(),
+            k.xy()*e.x13() + k.yy()*e.x23() + k.yz()*e.x33(),
+            k.xy()*e.x14() + k.yy()*e.x24() + k.yz()*e.x34(),
+            k.xy()*e.x15() + k.yy()*e.x25() + k.yz()*e.x35(),
+            k.xy()*e.x16() + k.yy()*e.x26() + k.yz()*e.x36(),
+            k.xz()*e.x11() + k.yz()*e.x21() + k.zz()*e.x31(),
+            k.xz()*e.x12() + k.yz()*e.x22() + k.zz()*e.x32(),
+            k.xz()*e.x13() + k.yz()*e.x23() + k.zz()*e.x33(),
+            k.xz()*e.x14() + k.yz()*e.x24() + k.zz()*e.x34(),
+            k.xz()*e.x15() + k.yz()*e.x25() + k.zz()*e.x35(),
+            k.xz()*e.x16() + k.yz()*e.x26() + k.zz()*e.x36(),
+            false);//already transformed
 }
 
-/** Tensor multiply symmetric3x3 by MandelVector (6x1) **/
+/** Tensor multiply matrix3x3 by mandel3x6 (3x6) **/
 template <class T, class U>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 auto operator*(
-    symmetric3x3<T> const &tt,
-    mandel3x6<U> const &v
-    )
+    matrix3x3<T> const &k,
+    mandel3x6<U> const &e)
 {
-    mandel6x1<U> vv = v;
-    vv.invMandelXform();
-
-    using result_type = decltype(tt.xx() * v.xx());
-    return mandel6x1<result_type>(
-          tt.xx()*vv.x1()+tt.xy()*vv.x6()+tt.xz()*vv.x5(),
-          tt.xy()*vv.x6()+tt.yy()*vv.x2()+tt.yz()*vv.x4(),
-          tt.xz()*vv.x5()+tt.yz()*vv.x4()+tt.zz()*vv.x3(),
-          tt.xy()*vv.x5()+tt.yy()*vv.x4()+tt.yz()*vv.x3(),
-          tt.xx()*vv.x5()+tt.xy()*vv.x4()+tt.xz()*vv.x3(),
-          tt.xx()*vv.x6()+tt.xy()*vv.x2()+tt.xz()*vv.x4(),
-          true);
+    return mandel3x6<decltype(k.xx()*e.x11())>(
+            k.xx()*e.x11() + k.xy()*e.x21() + k.xz()*e.x31(),
+            k.xx()*e.x12() + k.xy()*e.x22() + k.xz()*e.x32(),
+            k.xx()*e.x13() + k.xy()*e.x23() + k.xz()*e.x33(),
+            k.xx()*e.x14() + k.xy()*e.x24() + k.xz()*e.x34(),
+            k.xx()*e.x15() + k.xy()*e.x25() + k.xz()*e.x35(),
+            k.xx()*e.x16() + k.xy()*e.x26() + k.xz()*e.x36(),
+            k.yx()*e.x11() + k.yy()*e.x21() + k.yz()*e.x31(),
+            k.yx()*e.x12() + k.yy()*e.x22() + k.yz()*e.x32(),
+            k.yx()*e.x13() + k.yy()*e.x23() + k.yz()*e.x33(),
+            k.yx()*e.x14() + k.yy()*e.x24() + k.yz()*e.x34(),
+            k.yx()*e.x15() + k.yy()*e.x25() + k.yz()*e.x35(),
+            k.yx()*e.x16() + k.yy()*e.x26() + k.yz()*e.x36(),
+            k.zx()*e.x11() + k.zy()*e.x21() + k.zz()*e.x31(),
+            k.zx()*e.x12() + k.zy()*e.x22() + k.zz()*e.x32(),
+            k.zx()*e.x13() + k.zy()*e.x23() + k.zz()*e.x33(),
+            k.zx()*e.x14() + k.zy()*e.x24() + k.zz()*e.x34(),
+            k.zx()*e.x15() + k.zy()*e.x25() + k.zz()*e.x35(),
+            k.zx()*e.x16() + k.zy()*e.x26() + k.zz()*e.x36(),
+            false);//already transformed
 }
 
-/** Tensor multiply MandelVector (6x1) by diagonal3x3 (3x3) **/
+/** Tensor multiply mandel6x1 (as symmetric 3x3) by mandel3x6 (3x6) **/
 template <class T, class U>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-auto operator*(mandel6x1<T> const &v, diagonal3x3<U> const &tt)
+auto operator*(
+    mandel6x1<T> const &j,
+    mandel3x6<U> const &e)
 {
-    mandel6x1<T> vv = v;
-    vv.invMandelXform();
-
-    using result_type = decltype(tt.xx() * v.xx());
-    return mandel6x1<result_type>(
-          tt.xx()*vv.x1(),
-          tt.yy()*vv.x2(),
-          tt.zz()*vv.x3(),
-          tt.yy()*vv.x4(),
-          tt.xx()*vv.x5(),
-          tt.xx()*vv.x6(),
-          true);
-}
-
-/** Tensor multiply diagonal3x3 (3x3) by MandelVector (6x1) **/
-template <class T, class U>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-auto operator*(diagonal3x3<T> const &tt, mandel6x1<U> const &vv)
-{
-    using result_type = decltype(tt.xx() * vv.xx());
-    return mandel6x1<result_type>(
-          tt.xx()*vv.x1(),
-          tt.yy()*vv.x2(),
-          tt.zz()*vv.x3(),
-          tt.yy()*vv.x4(),
-          tt.xx()*vv.x5(),
-          tt.xx()*vv.x6(),
-          false);
+    mandel6x1 k = j;
+    k.invMandelXform();
+    return mandel3x6<decltype(k.x1()*e.x11())>(
+            k.x1()*e.x11() + k.x6()*e.x21() + k.x5()*e.x31(),
+            k.x1()*e.x12() + k.x6()*e.x22() + k.x5()*e.x32(),
+            k.x1()*e.x13() + k.x6()*e.x23() + k.x5()*e.x33(),
+            k.x1()*e.x14() + k.x6()*e.x24() + k.x5()*e.x34(),
+            k.x1()*e.x15() + k.x6()*e.x25() + k.x5()*e.x35(),
+            k.x1()*e.x16() + k.x6()*e.x26() + k.x5()*e.x36(),
+            k.x6()*e.x11() + k.x2()*e.x21() + k.x4()*e.x31(),
+            k.x6()*e.x12() + k.x2()*e.x22() + k.x4()*e.x32(),
+            k.x6()*e.x13() + k.x2()*e.x23() + k.x4()*e.x33(),
+            k.x6()*e.x14() + k.x2()*e.x24() + k.x4()*e.x34(),
+            k.x6()*e.x15() + k.x2()*e.x25() + k.x4()*e.x35(),
+            k.x6()*e.x16() + k.x2()*e.x26() + k.x4()*e.x36(),
+            k.x5()*e.x11() + k.x4()*e.x21() + k.x3()*e.x31(),
+            k.x5()*e.x12() + k.x4()*e.x22() + k.x3()*e.x32(),
+            k.x5()*e.x13() + k.x4()*e.x23() + k.x3()*e.x33(),
+            k.x5()*e.x14() + k.x4()*e.x24() + k.x3()*e.x34(),
+            k.x5()*e.x15() + k.x4()*e.x25() + k.x3()*e.x35(),
+            k.x5()*e.x16() + k.x4()*e.x26() + k.x3()*e.x36(),
+            false);//already transformed
 }
 
 //misc
 inline int constexpr mandel3x6_component_count = 18;
+
+}

--- a/p3a_mandel3x6.hpp
+++ b/p3a_mandel3x6.hpp
@@ -553,4 +553,18 @@ auto operator*(
 //misc
 inline int constexpr mandel3x6_component_count = 18;
 
+//output print
+template <class U>
+P3A_ALWAYS_INLINE constexpr 
+std::ostream& operator<<(std::ostream& os, mandel3x6<U> const& a)
+{
+  os << std::cout.precision(4);
+  os << std::scientific;
+  os << "\t  | " << a.x11() << " " << a.x12() << " " << a.x13() << " " << a.x14()*a.r2 << " " << a.x15()*a.r2 << " " << a.x16*a.r2 << " |" <<std::endl;
+  os << "\t  | " << a.x21() << " " << a.x22() << " " << a.x23() << " " << a.x24()*a.r2 << " " << a.x25()*a.r2 << " " << a.x26*a.r2 << " |" <<std::endl;
+  os << "\t  | " << a.x31() << " " << a.x32() << " " << a.x33() << " " << a.x34()*a.r2 << " " << a.x35()*a.r2 << " " << a.x36*a.r2 << " |" <<std::endl;
+
+  return os;
+}
+
 }

--- a/p3a_mandel3x6.hpp
+++ b/p3a_mandel3x6.hpp
@@ -1,0 +1,534 @@
+#pragma once
+
+#include "p3a_macros.hpp"
+#include "p3a_diagonal3x3.hpp"
+#include "p3a_vector3.hpp"
+#include "p3a_symmetric3x3.hpp"
+#include "p3a_matrix3x3.hpp"
+#include "p3a_mandel6x1.hpp"
+#include "p3a_mandel6x6.hpp"
+/********************************* NOTES ************************************
+ * This header provides the class: 
+ *
+ * - `mandel3x6` (3x6) 3rd order Tensor
+ *
+ * See additional notes in `p3a_mandel6x1.hpp`.
+ */
+
+namespace p3a {
+
+/******************************************************************/
+/******************************************************************/
+template <class T>
+class Mandel3x6
+/** 
+ * Represents a 3rd order tensor as a 3x6 Mandel array
+ */
+/******************************************************************/
+{
+ T x11,x12,x13,x14,x15,x16,
+   x21,x22,x23,x24,x25,x26,
+   x31,x32,x33,x34,x35,x36;
+ bool applyTransform;
+
+ const T r2 = std::sqrt(T(2.0));
+ const T r2i = T(1.0)/std::sqrt(T(2.0));
+ const T two = T(2.0);
+
+ public:
+  /**** constructors, destructors, and assigns ****/
+  P3A_ALWAYS_INLINE constexpr
+  mandel3x6() = default;
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel3x6(
+      T const& X11, T const& X12, T const& X13, T const& X14, T const& X15, T const& X16,
+      T const& X21, T const& X22, T const& X23, T const& X24, T const& X25, T const& X26,
+      T const& X31, T const& X32, T const& X33, T const& X34, T const& X35, T const& X36):
+      x11(X11),x12(X12),x13(X13),x14(X14),x15(X15),x16(X16),
+      x21(X21),x22(X22),x23(X23),x24(X24),x25(X25),x26(X26),
+      x31(X31),x32(X32),x33(X33),x34(X34),x35(X35),x36(X36),
+      applyTransform(true)
+  {
+    if (applyTransform)
+        this->MandelXform();
+  }
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel3x6(
+    T const& X11, T const& X12, T const& X13, T const& X14, T const& X15, T const& X16,
+    T const& X21, T const& X22, T const& X23, T const& X24, T const& X25, T const& X26,
+    T const& X31, T const& X32, T const& X33, T const& X34, T const& X35, T const& X36,
+    bool const& Xform):
+    x11(X11),x12(X12),x13(X13),x14(X14),x15(X15),x16(X16),
+    x21(X21),x22(X22),x23(X23),x24(X24),x25(X25),x26(X26),
+    x31(X31),x32(X32),x33(X33),x34(X34),x35(X35),x36(X36),
+    applyTransform(Xform)
+  {
+    if (applyTransform)
+        this->MandelXform();
+  }
+
+  //return by mandel index 1-6
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x11() const { return x11; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x12() const { return x12; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x13() const { return x13; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x14() const { return x14; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x15() const { return x15; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x16() const { return x16; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x21() const { return x21; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x22() const { return x22; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x23() const { return x23; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x24() const { return x24; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x25() const { return x25; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x26() const { return x26; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x31() const { return x31; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x32() const { return x32; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x33() const { return x33; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x34() const { return x34; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x35() const { return x35; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x36() const { return x36; }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x11() { return x11; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x12() { return x12; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x13() { return x13; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x14() { return x14; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x15() { return x15; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x16() { return x16; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x21() { return x21; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x22() { return x22; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x23() { return x23; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x24() { return x24; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x25() { return x25; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x26() { return x26; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x31() { return x31; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x32() { return x32; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x33() { return x33; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x34() { return x34; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x35() { return x35; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x36() { return x36; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  mandel3x6<T> zero()
+  {
+    return mandel3x6<T>(
+        T(0), T(0), T(0), T(0), T(0), T(0),
+        T(0), T(0), T(0), T(0), T(0), T(0),
+        T(0), T(0), T(0), T(0), T(0), T(0),
+        false);
+  }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  mandel6x6<T> identity()
+  {
+    return mandel3x6<T>(
+        T(1), T(0), T(0), T(0), T(0), T(0),
+        T(0), T(1), T(0), T(0), T(0), T(0),
+        T(0), T(0), T(1), T(0), T(0), T(0),
+        true);
+  }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  void MandelXform()
+  {
+        x14*=r2i, x15*=r2i, x16*=r2i, 
+        x24*=r2i, x25*=r2i, x26*=r2i,
+        x34*=r2i, x35*=r2i, x36*=r2i;
+  }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  void invMandelXform()
+  {
+        x14/=r2i, x15/=r2i, x16/=r2i, 
+        x24/=r2i, x25/=r2i, x26/=r2i,
+        x34/=r2i, x35/=r2i, x36/=r2i;
+  }
+
+};
+
+/***************************************************************************** 
+ * Operator overloads for mandel3x6 tensors (3rd order tensor)
+ *****************************************************************************/
+//mandel3x6 binary operators with scalars
+//multiplication by constant
+template <class A, class B>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+typename std::enable_if<is_scalar<B>, mandel3x6<decltype(A() * B())>>::type
+operator*(
+        mandel3x6<A> const& a, 
+        B const& c)
+{
+    return mandel3x6<decltype(a.x11()*c)>(
+            a.x11()*c, a.x12()*c, a.x13()*c, a.x14()*c, a.x15()*c, a.x16()*c,
+            a.x21()*c, a.x22()*c, a.x23()*c, a.x24()*c, a.x25()*c, a.x26()*c,
+            a.x31()*c, a.x32()*c, a.x33()*c, a.x34()*c, a.x35()*c, a.x36()*c,
+            false);
+}
+
+//multiplication by constant
+template <class A, class B>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+typename std::enable_if<is_scalar<A>, mandel3x6<decltype(A() * B())>>::type 
+operator*(
+        A const& c, 
+        mandel3x6<B> const& t)
+{
+    return t * c;
+}
+
+//division by constant
+template <class A, class B>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+typename std::enable_if<is_scalar<B>, mandel3x6<decltype(A() * B())>>::type
+operator/(
+        mandel3x6<A> const& a, 
+        B const& c)
+{
+    return mandel6x6<decltype<(a.x11() / c)>(
+            a.x11()/c, a.x12()/c, a.x13()/c, a.x14()/c, a.x15()/c, a.x16()/c,
+            a.x21()/c, a.x22()/c, a.x23()/c, a.x24()/c, a.x25()/c, a.x26()/c,
+            a.x31()/c, a.x32()/c, a.x33()/c, a.x34()/c, a.x35()/c, a.x36()/c,
+            false);
+}
+
+//division /= by constant
+template <class A>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator/=(
+        mandel3x6<A>& a, 
+        A const& c)
+{
+        a.x11()/=c; 
+        a.x12()/=c; 
+        a.x13()/=c; 
+        a.x14()/=c; 
+        a.x15()/=c;
+        a.x16()/=c;
+        a.x21()/=c;
+        a.x22()/=c;
+        a.x23()/=c;
+        a.x24()/=c;
+        a.x25()/=c;
+        a.x26()/=c;
+        a.x31()/=c;
+        a.x32()/=c;
+        a.x33()/=c;
+        a.x34()/=c;
+        a.x35()/=c;
+        a.x36()/=c;
+}
+
+//multiplication *= by constant
+template <class A>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator*=(
+        mandel3x6<A>& a, 
+        A const& c)
+{
+        a.x11()*=c; 
+        a.x12()*=c; 
+        a.x13()*=c; 
+        a.x14()*=c; 
+        a.x15()*=c;
+        a.x16()*=c;
+        a.x21()*=c;
+        a.x22()*=c;
+        a.x23()*=c;
+        a.x24()*=c;
+        a.x25()*=c;
+        a.x26()*=c;
+        a.x31()*=c;
+        a.x32()*=c;
+        a.x33()*=c;
+        a.x34()*=c;
+        a.x35()*=c;
+        a.x36()*=c;
+}
+
+//mandel3x6 += addition
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator+=(
+    mandel3x6<T>& a, 
+    mandel3x6<T> const& b)
+{
+    a.x11() += b.x11();
+    a.x12() += b.x12();
+    a.x13() += b.x13();
+    a.x14() += b.x14();
+    a.x15() += b.x15();
+    a.x16() += b.x16();
+    a.x21() += b.x21();
+    a.x22() += b.x22();
+    a.x23() += b.x23(); 
+    a.x24() += b.x24();
+    a.x25() += b.x25();
+    a.x26() += b.x26();
+    a.x31() += b.x31();
+    a.x32() += b.x32();
+    a.x33() += b.x33(); 
+    a.x34() += b.x34();
+    a.x35() += b.x35();
+    a.x36() += b.x36();
+}
+
+//mandel3x6 -= subtraction
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator-=(
+    mandel3x6<T>& a, 
+    mandel3x6<T> const& b)
+{
+    a.x11() -= b.x11();
+    a.x12() -= b.x12();
+    a.x13() -= b.x13();
+    a.x14() -= b.x14();
+    a.x15() -= b.x15();
+    a.x16() -= b.x16();
+    a.x21() -= b.x21();
+    a.x22() -= b.x22();
+    a.x23() -= b.x23(); 
+    a.x24() -= b.x24();
+    a.x25() -= b.x25();
+    a.x26() -= b.x26();
+    a.x31() -= b.x31();
+    a.x32() -= b.x32();
+    a.x33() -= b.x33(); 
+    a.x34() -= b.x34();
+    a.x35() -= b.x35();
+    a.x36() -= b.x36();
+}
+
+//mandel3x6 addition
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator+(
+    mandel3x6<T> const& a, 
+    mandel3x6<U> const& b)
+{
+  return mandel3x6<decltype(a.x11()+b.x11())>(
+    a.x11() + b.x11(), a.x12() + b.x12(), a.x13() + b.x13(), a.x14() + b.x14(), a.x15() + b.x15(), a.x16() + b.x16(),
+    a.x21() + b.x21(), a.x22() + b.x22(), a.x23() + b.x23(), a.x24() + b.x24(), a.x25() + b.x25(), a.x26() + b.x26(),
+    a.x31() + b.x31(), a.x32() + b.x32(), a.x33() + b.x33(), a.x34() + b.x34(), a.x35() + b.x35(), a.x36() + b.x36(),
+    false);
+}
+
+//mandel3x6 subtraction
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator-(
+    mandel3x6<T> const& a, 
+    mandel3x6<U> const& b)
+{
+  return mandel3x6<decltype(a.x11()-b.x11())>(
+    a.x11() - b.x11(), a.x12() - b.x12(), a.x13() - b.x13(), a.x14() - b.x14(), a.x15() - b.x15(), a.x16() - b.x16(),
+    a.x21() - b.x21(), a.x22() - b.x22(), a.x23() - b.x23(), a.x24() - b.x24(), a.x25() - b.x25(), a.x26() - b.x26(),
+    a.x31() - b.x31(), a.x32() - b.x32(), a.x33() - b.x33(), a.x34() - b.x34(), a.x35() - b.x35(), a.x36() - b.x36(),
+    false);
+}
+
+//mandel3x6 negation
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+mandel3x6<T> operator-(
+    mandel3x6<T> const& a)
+{
+  return mandel3x6<T>(
+    -a.x11(), -a.x12(), -a.x13(), -a.x14(), -a.x15(), -a.x16(),
+    -a.x21(), -a.x22(), -a.x23(), -a.x24(), -a.x25(), -a.x26(),
+    -a.x31(), -a.x32(), -a.x33(), -a.x34(), -a.x35(), -a.x36(),
+    false);
+}
+
+/***************************************************************************** 
+ * Linear Algebra for mandel3x6 (3rd order tensor)
+ *****************************************************************************/
+//trace
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+T trace(
+    mandel3x6<T> const& a)
+{
+  return a.x11() + a.x22() + a.x33();
+}
+
+/** Tensor multiply mandel3x6 (3x6) by mandel6x1 (6x1) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel3x6<T> const &C,
+    mandel6x1<U> const &v)
+{
+    return vector3<decltype(C.x11()*v.x1())>(
+        (C.x11()*v.x1() + C.x12()*v.x2() + C.x13()*v.x3() + C.x14()*v.x4() + C.x15()*v.x5() + C.x16()*v.x6()),
+        (C.x21()*v.x1() + C.x22()*v.x2() + C.x23()*v.x3() + C.x24()*v.x4() + C.x25()*v.x5() + C.x26()*v.x6()),
+        (C.x31()*v.x1() + C.x32()*v.x2() + C.x33()*v.x3() + C.x34()*v.x4() + C.x35()*v.x5() + C.x36()*v.x6()))
+}
+
+/** Tensor multiply mandel3x6 (3x6) by mandel6x6 (6x6) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel3x6<T> const &e,
+    mandel6x6<U> const &k)
+{
+    return mandel3x6<decltype(e.x11()*k.x11())>(
+            e.x11()*k.x11() + e.x12()*k.x21() + e.x13()*k.x31() + e.x14()*k.x41() + e.x15()*k.x51() + e.x16()*k.x61(),
+            e.x11()*k.x12() + e.x12()*k.x22() + e.x13()*k.x32() + e.x14()*k.x42() + e.x15()*k.x52() + e.x16()*k.x62(),
+            e.x11()*k.x13() + e.x12()*k.x23() + e.x13()*k.x33() + e.x14()*k.x43() + e.x15()*k.x53() + e.x16()*k.x63(),
+            e.x11()*k.x14() + e.x12()*k.x24() + e.x13()*k.x34() + e.x14()*k.x44() + e.x15()*k.x54() + e.x16()*k.x64(),
+            e.x11()*k.x15() + e.x12()*k.x25() + e.x13()*k.x35() + e.x14()*k.x45() + e.x15()*k.x55() + e.x16()*k.x65(),
+            e.x11()*k.x16() + e.x12()*k.x26() + e.x13()*k.x36() + e.x14()*k.x46() + e.x15()*k.x56() + e.x16()*k.x66(),
+            e.x21()*k.x11() + e.x22()*k.x21() + e.x23()*k.x31() + e.x24()*k.x41() + e.x25()*k.x51() + e.x26()*k.x61(),
+            e.x21()*k.x12() + e.x22()*k.x22() + e.x23()*k.x32() + e.x24()*k.x42() + e.x25()*k.x52() + e.x26()*k.x62(),
+            e.x21()*k.x13() + e.x22()*k.x23() + e.x23()*k.x33() + e.x24()*k.x43() + e.x25()*k.x53() + e.x26()*k.x63(),
+            e.x21()*k.x14() + e.x22()*k.x24() + e.x23()*k.x34() + e.x24()*k.x44() + e.x25()*k.x54() + e.x26()*k.x64(),
+            e.x21()*k.x15() + e.x22()*k.x25() + e.x23()*k.x35() + e.x24()*k.x45() + e.x25()*k.x55() + e.x26()*k.x65(),
+            e.x21()*k.x16() + e.x22()*k.x26() + e.x23()*k.x36() + e.x24()*k.x46() + e.x25()*k.x56() + e.x26()*k.x66(),
+            e.x31()*k.x11() + e.x32()*k.x21() + e.x33()*k.x31() + e.x34()*k.x41() + e.x35()*k.x51() + e.x36()*k.x61(),
+            e.x31()*k.x12() + e.x32()*k.x22() + e.x33()*k.x32() + e.x34()*k.x42() + e.x35()*k.x52() + e.x36()*k.x62(),
+            e.x31()*k.x13() + e.x32()*k.x23() + e.x33()*k.x33() + e.x34()*k.x43() + e.x35()*k.x53() + e.x36()*k.x63(),
+            e.x31()*k.x14() + e.x32()*k.x24() + e.x33()*k.x34() + e.x34()*k.x44() + e.x35()*k.x54() + e.x36()*k.x64(),
+            e.x31()*k.x15() + e.x32()*k.x25() + e.x33()*k.x35() + e.x34()*k.x45() + e.x35()*k.x55() + e.x36()*k.x65(),
+            e.x31()*k.x16() + e.x32()*k.x26() + e.x33()*k.x36() + e.x34()*k.x46() + e.x35()*k.x56() + e.x36()*k.x66(),
+            false);//already transformed
+}
+
+/** Tensor multiply mandel3x6 (3x6) by mandel6x6 (6x6) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel3x6<T> const &e,
+    mandel6x6<U> const &k)
+{
+    return mandel3x6<decltype(e.x11()*k.x11())>(
+            e.x11()*k.x11() + e.x12()*k.x21() + e.x13()*k.x31() + e.x14()*k.x41() + e.x15()*k.x51() + e.x16()*k.x61(),
+            e.x11()*k.x12() + e.x12()*k.x22() + e.x13()*k.x32() + e.x14()*k.x42() + e.x15()*k.x52() + e.x16()*k.x62(),
+            e.x11()*k.x13() + e.x12()*k.x23() + e.x13()*k.x33() + e.x14()*k.x43() + e.x15()*k.x53() + e.x16()*k.x63(),
+            e.x11()*k.x14() + e.x12()*k.x24() + e.x13()*k.x34() + e.x14()*k.x44() + e.x15()*k.x54() + e.x16()*k.x64(),
+            e.x11()*k.x15() + e.x12()*k.x25() + e.x13()*k.x35() + e.x14()*k.x45() + e.x15()*k.x55() + e.x16()*k.x65(),
+            e.x11()*k.x16() + e.x12()*k.x26() + e.x13()*k.x36() + e.x14()*k.x46() + e.x15()*k.x56() + e.x16()*k.x66(),
+            e.x21()*k.x11() + e.x22()*k.x21() + e.x23()*k.x31() + e.x24()*k.x41() + e.x25()*k.x51() + e.x26()*k.x61(),
+            e.x21()*k.x12() + e.x22()*k.x22() + e.x23()*k.x32() + e.x24()*k.x42() + e.x25()*k.x52() + e.x26()*k.x62(),
+            e.x21()*k.x13() + e.x22()*k.x23() + e.x23()*k.x33() + e.x24()*k.x43() + e.x25()*k.x53() + e.x26()*k.x63(),
+            e.x21()*k.x14() + e.x22()*k.x24() + e.x23()*k.x34() + e.x24()*k.x44() + e.x25()*k.x54() + e.x26()*k.x64(),
+            e.x21()*k.x15() + e.x22()*k.x25() + e.x23()*k.x35() + e.x24()*k.x45() + e.x25()*k.x55() + e.x26()*k.x65(),
+            e.x21()*k.x16() + e.x22()*k.x26() + e.x23()*k.x36() + e.x24()*k.x46() + e.x25()*k.x56() + e.x26()*k.x66(),
+            e.x31()*k.x11() + e.x32()*k.x21() + e.x33()*k.x31() + e.x34()*k.x41() + e.x35()*k.x51() + e.x36()*k.x61(),
+            e.x31()*k.x12() + e.x32()*k.x22() + e.x33()*k.x32() + e.x34()*k.x42() + e.x35()*k.x52() + e.x36()*k.x62(),
+            e.x31()*k.x13() + e.x32()*k.x23() + e.x33()*k.x33() + e.x34()*k.x43() + e.x35()*k.x53() + e.x36()*k.x63(),
+            e.x31()*k.x14() + e.x32()*k.x24() + e.x33()*k.x34() + e.x34()*k.x44() + e.x35()*k.x54() + e.x36()*k.x64(),
+            e.x31()*k.x15() + e.x32()*k.x25() + e.x33()*k.x35() + e.x34()*k.x45() + e.x35()*k.x55() + e.x36()*k.x65(),
+            e.x31()*k.x16() + e.x32()*k.x26() + e.x33()*k.x36() + e.x34()*k.x46() + e.x35()*k.x56() + e.x36()*k.x66(),
+            false);//already transformed
+}
+
+/** Tensor multiply symmetric3x3 (3x3) by mandel3x6 (3x6) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    symmetric3x3<U> const &s)
+    mandel3x6<T> const &C, 
+{
+    v = mandel6x1<T>(s);
+    return C*v;
+}
+
+/** Tensor multiply symmetric3x3 by MandelVector (6x1) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    symmetric3x3<T> const &tt,
+    mandel3x6<U> const &v
+    )
+{
+    mandel6x1<U> vv = v;
+    vv.invMandelXform();
+
+    using result_type = decltype(tt.xx() * v.xx());
+    return mandel6x1<result_type>(
+          tt.xx()*vv.x1()+tt.xy()*vv.x6()+tt.xz()*vv.x5(),
+          tt.xy()*vv.x6()+tt.yy()*vv.x2()+tt.yz()*vv.x4(),
+          tt.xz()*vv.x5()+tt.yz()*vv.x4()+tt.zz()*vv.x3(),
+          tt.xy()*vv.x5()+tt.yy()*vv.x4()+tt.yz()*vv.x3(),
+          tt.xx()*vv.x5()+tt.xy()*vv.x4()+tt.xz()*vv.x3(),
+          tt.xx()*vv.x6()+tt.xy()*vv.x2()+tt.xz()*vv.x4(),
+          true);
+}
+
+/** Tensor multiply MandelVector (6x1) by diagonal3x3 (3x3) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(mandel6x1<T> const &v, diagonal3x3<U> const &tt)
+{
+    mandel6x1<T> vv = v;
+    vv.invMandelXform();
+
+    using result_type = decltype(tt.xx() * v.xx());
+    return mandel6x1<result_type>(
+          tt.xx()*vv.x1(),
+          tt.yy()*vv.x2(),
+          tt.zz()*vv.x3(),
+          tt.yy()*vv.x4(),
+          tt.xx()*vv.x5(),
+          tt.xx()*vv.x6(),
+          true);
+}
+
+/** Tensor multiply diagonal3x3 (3x3) by MandelVector (6x1) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(diagonal3x3<T> const &tt, mandel6x1<U> const &vv)
+{
+    using result_type = decltype(tt.xx() * vv.xx());
+    return mandel6x1<result_type>(
+          tt.xx()*vv.x1(),
+          tt.yy()*vv.x2(),
+          tt.zz()*vv.x3(),
+          tt.yy()*vv.x4(),
+          tt.xx()*vv.x5(),
+          tt.xx()*vv.x6(),
+          false);
+}
+
+
+//misc
+inline int constexpr mandel3x6_component_count = 18;
+

--- a/p3a_mandel6x1.hpp
+++ b/p3a_mandel6x1.hpp
@@ -1,0 +1,748 @@
+#pragma once
+
+#include "p3a_macros.hpp"
+#include "p3a_diagonal3x3.hpp"
+#include "p3a_vector3.hpp"
+#include "p3a_symmetric3x3.hpp"
+#include "p3a_matrix3x3.hpp"
+/********************************* NOTES ************************************
+ *
+ * Symmetric Tensor (Voigt-Mandel) Math Library
+ * ============================================
+ *
+ * Scope of the Library
+ * ----------------------------------
+ * This set of classes and functions allows for linear algebra to be performed
+ * in the context of material models. This package enables the usual linear
+ * algebra operations with symmetric 1x6, 6x1, 6x6, 6x3, and 3x6 tensors and 
+ * is able to perform mixed operations with the `diagonal3x3`, `symmetric3x3` 
+ * and `matrix3x3` classes also avaliable in P3A.  operations are carried out 
+ * component by component, elimininating the need for arrays and permitting 
+ * functions to be _inline_ consistent with the performance requirements of
+ * P3A. 
+ *
+ * This header provides the class: 
+ *
+ * - `mandel6x1` (6x1) 2nd order Tensor
+ *
+ * Other `mandelNxN` headers provide the classes:
+ *
+ * - `mandel6x6` (6x6) 4th order Tensor
+ * - `mandel3x6` (3x6) 3rd order Tensor
+ * - `mandel6x3` (6x3) 3rd order Tensor
+ *
+ * Mandel Notation and Voigt Notation
+ * ----------------------------------
+ * The primary addition of this library is the ability to perform the usual
+ * linear algebra relations with normal Tensors and Vectors along with symmetric 
+ * ones often found in mechanics. This package uses *Mandel* notation, not 
+ * _Voigt_ notation. Mandel notation is simmilar to Voigt's notation in that
+ * symmetric 2<sup>nd</sup>-order tensors are represented by 6x1 vectors, and 
+ * 4<sup>th</sup>-order tensors are represented by 6x6 tensors. Mandel notation 
+ * is applied to all tensors/vectors unlike Voigt notation. 
+ *
+ * Mandel notation allows for all standard linear algebra operations to be
+ * correctly normalized and eliminates the need for strain, or stress-like Voigt
+ * tensors (symmetric strain-like tensors will have of 2 in front of off-diagonal 
+ * components, while stress like tensors will have a factor of 1). Converting 
+ * to Mandel notation (which properly normalizes the tensor) will ease computations
+ * with operations produce vectors (3x1) or full (3x3) 2<sup>nd</sup>-order tensors.
+ *
+ * Mandel Transformation is applied internally upon construction of a Mandel-type 
+ * object which includes all of the symmetric Mandel Tensor types (6x1, 6x6, 3x6, 
+ * or 6x3). By default, all constructors apply the Mandel Transform, but it can be 
+ * overridden by specifying a Boolean `false` value to the end of the constructor 
+ * argument list. Note that, if you use the `zero()` or `identity()` constructor, 
+ * you will have a tensor that won't carry the transform to further operations, the 
+ * transformation must be applied manually by applying the method `MandelXform()` 
+ * method to the Mandel-type object. The transform will be contained in any result 
+ * returning a Mandel-type object. This means that the Mandel transformation must be 
+ * inverted when converting MandelVectors (6-element symmetric tensors) to full 
+ * 9-element (3x3) 2<sup>nd</sup>-order tensors. 
+ *
+ * This library automatically inverts the Mandel transformation when returning a
+ * member of the `matrix3x3` or `symmetric3x3` classes. Operations that 
+ * return Vectors will not need to be modified (this is why we are using Mandel 
+ * transformations)!  
+ *
+ */
+
+namespace p3a {
+
+template <class T>
+static bool compare(T a, T b){
+    return std::fabs(a-b) <= epsilon_value<T>();
+
+/******************************************************************/
+/******************************************************************/
+template <class T>
+class Mandel6x1
+/** 
+ * Represents a 2nd order tensor as a 6x1 Mandel array
+ */
+/******************************************************************/
+{
+ T x1,x2,x3,x4,x5,x6;
+ bool applyTransform;
+
+ const T r2 = std::sqrt(T(2.0));
+ const T r2i = T(1.0)/std::sqrt(T(2.0));
+ const T two = T(2.0);
+
+ public:
+  /**** constructors, destructors, and assigns ****/
+  P3A_ALWAYS_INLINE constexpr
+  mandel6x1() = default;
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x1(
+      T const& X1, T const& X2, T const& X3,
+      T const& X4, T const& X5, T const& X6):
+       x1(X1),
+       x2(X2),
+       x3(X3),
+       x4(X4),
+       x5(X5),
+       x6(X6),
+       applyTransform(true)
+  {
+    if (applyTransform)
+        this->MandelXform();
+  }
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x1(
+      T const& X1, T const& X2, T const& X3,
+      T const& X4, T const& X5, T const& X6, bool const& Xform)
+    :x1(X1)
+    ,x2(X2)
+    ,x3(X3)
+    ,x4(X4)
+    ,x5(X5)
+    ,x6(X6)
+    ,applyTransform(Xform)
+  {
+    if (applyTransform)
+        this->MandelXform();
+  }
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x1(symmetric3x3<T> const& a):
+    x1(a.xx()),
+    x2(a.yy()),
+    x3(a.zz()),
+    x4(a.yz()),
+    x5(a.xz()),
+    x6(a.xy()),
+    applyTransform(true)
+  {
+    if (applyTransform)
+        this->MandelXform();
+  }
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x1(symmetric3x3<T> const& a, bool const& Xform):
+    x1(a.xx()),
+    x2(a.yy()),
+    x3(a.zz()),
+    x4(a.yz()),
+    x5(a.xz()),
+    x6(a.xy()),
+    applyTransform(Xform)
+  {
+    if (applyTransform)
+        this->MandelXform();
+  }
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x1(diagonal3x3<T> const& a, bool const& Xform):
+    x1(a.xx()),
+    x2(a.yy()),
+    x3(a.zz()),
+    x4(T(0.0)),
+    x5(T(0.0)),
+    x6(T(0.0)),
+    applyTransform(Xform)
+  {
+    if (applyTransform)
+        this->MandelXform();
+  }
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x1(diagonal3x3<T> const& a):
+    x1(a.xx()),
+    x2(a.yy()),
+    x3(a.zz()),
+    x4(T(0.0)),
+    x5(T(0.0)),
+    x6(T(0.0)),
+    applyTransform(true)
+  {
+    if (applyTransform)
+        this->MandelXform();
+  }
+
+  //Return components by ij descriptor
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& xx() const { return x1; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& yy() const { return x2; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& zz() const { return x3; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& yz() const { return x4; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& xz() const { return x5; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& xy() const { return x6; }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& xx() { return x1; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& yy() { return x2; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& zz() { return x3; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& yz() { return x4; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& xz() { return x5; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& xy() { return x6; }
+
+  //return by mandel index 1-6
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x1() const { return x1; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x2() const { return x2; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x3() const { return x3; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x4() const { return x4; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x5() const { return x5; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x6() const { return x6; }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x1() { return x1; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x2() { return x2; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x3() { return x3; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x4() { return x4; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x5() { return x5; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x6() { return x6; }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  mandel6x1<T> zero()
+  {
+    return mandel6x1<T>(
+        T(0), T(0), T(0),
+        T(0), T(0), T(0),false);
+  }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  mandel6x1<T> identity()
+  {
+    return mandel6x1<T>(
+        T(1), T(1), T(1),
+        T(0), T(0), T(0),true);
+  }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  void MandelXform()
+  {
+      x4 *= r2;
+      x5 *= r2;
+      x6 *= r2;
+  }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  void invMandelXform()
+  {
+      x4 /= r2;
+      x5 /= r2;
+      x6 /= r2;
+  }
+
+};
+
+/***************************************************************************** 
+ * Operators overloads for mandel6x1 tensors (2nd order tensor)
+ *****************************************************************************/
+//conversion of symmetric3x3 to mande6x1 via assignment
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator=(
+    symmetric3x3<T> const& t)
+{
+    return mandel6x1<T>(
+            t.xx(),
+            t.yy(),
+            t.zz(),
+            t.yz(),
+            t.xz(),
+            t.xy(),
+            true);
+}
+
+//conversion of mandel6x1 to symmetric3x3 via assignment
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+symmetric3x3<T> operator=(
+    madel6x1<T> const& tt)
+{
+    mandel6x1<T> t = tt;
+    t.invMandelXform();
+
+    return symmetric3x3<T>(
+            t.xx(),
+            t.yy(),
+            t.zz(),
+            t.yz(),
+            t.xz(),
+            t.xy());
+}
+
+//mandel6x1 binary operators with scalars
+//multiplication by constant
+template <class A, class B>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+typename std::enable_if<is_scalar<B>, mandel6x1<decltype(A() * B())>>::type
+operator*(
+    mandel6x1<A> const& t, 
+    B const& c)
+{
+    return mandel6x1<decltype(t.x1()*c)>(
+            a.x1()*c,
+            a.x2()*c,
+            a.x3()*c,
+            a.x4()*c,
+            a.x5()*c,
+            a.x6()*c,
+            false);
+}
+
+//multiplication by constant
+template <class A, class B>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+typename std::enable_if<is_scalar<A>, mandel6x1<decltype(A() * B())>>::type 
+operator*(
+    A const& c, 
+    mandel6x1<B> const& t)
+{
+    return t * c;
+}
+
+//division by constant
+template <class A, class B>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+typename std::enable_if<is_scalar<B>, mandel6x1<decltype(A() * B())>>::type
+operator/(
+    mandel6x1<A> const& t, 
+    B const& c)
+{
+    return mandel6x1<decltype<(t.x1() / c)>(
+            t.x1() / c,
+            t.x2() / c,
+            t.x3() / c,
+            t.x4() / c,
+            t.x5() / c,
+            t.x6() / c,
+            false);
+}
+
+//multiplication *= by constant
+template <class A>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator*=(
+    mandel6x1<A>& t, 
+    A const& c)
+{
+    t.x1() *= c;
+    t.x2() *= c;
+    t.x3() *= c;
+    t.x4() *= c;
+    t.x5() *= c;
+    t.x6() *= c;
+}
+
+//division /= by constant
+template <class A>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator/=(
+    mandel6x1<A>& t, 
+    A const& c)
+{
+    t.x1() /= c;
+    t.x2() /= c;
+    t.x3() /= c;
+    t.x4() /= c;
+    t.x5() /= c;
+    t.x6() /= c;
+}
+
+//mandel6x1 -= subtraction
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator-=(
+    mandel6x1<T>& a, 
+    mandel6x1<T> const& b)
+{
+    a.x1() -= b.x1();
+    a.x2() -= b.x2();
+    a.x3() -= b.x3();
+    a.x4() -= b.x4();
+    a.x5() -= b.x5();
+    a.x6() -= b.x6();
+}
+
+
+//mandel6x1 addition
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+mandel6x1<T> operator+(
+    mandel6x1<T> const& a, 
+    mandel6x1<U> const& b)
+{
+  using result_type (a.x11*b.x12)
+  return mandel6x1<result_type>(
+    a.x1() + b.x1(),
+    a.x2() + b.x2(),
+    a.x3() + b.x3(),
+    a.x4() + b.x4(),
+    a.x5() + b.x5(),
+    a.x6() + b.x6(),
+    false);
+}
+
+//mandel6x1 += addition
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator+=(
+    mandel6x1<T>& a, 
+    mandel6x1<T> const& b)
+{
+    a.x1() += b.x1();
+    a.x2() += b.x2();
+    a.x3() += b.x3();
+    a.x4() += b.x4();
+    a.x5() += b.x5();
+    a.x6() += b.x6();
+}
+
+//mandel6x1 subtraction
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+mandel6x1<T> operator-(
+    mandel6x1<T> const& a, 
+    mandel6x1<T> const& b)
+{
+  return mandel6x1<T>(
+    a.xx() - b.xx(),
+    a.xy() - b.xy(),
+    a.xz() - b.xz(),
+    a.yy() - b.yy(),
+    a.yz() - b.yz(),
+    a.zz() - b.zz(),
+    false);
+}
+
+//mandel6x1 negation
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+mandel6x1<T> operator-(
+    mandel6x1<T> const& a)
+{
+  return mandel6x1<T>(
+    -a.x1(),
+    -a.x2(),
+    -a.x3(),
+    -a.x4(),
+    -a.x5(),
+    -a.x6(),
+    false);
+}
+
+/***************************************************************************** 
+ * Linear Algebra for MandelVector (2nd order tensor)
+ *****************************************************************************/
+//trace
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+T trace(
+    mandel6x1<T> const& a)
+{
+  return a.x1() + a.x2() + a.x3();
+}
+
+//determinate
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+T Det(
+    mandel6x1<T> const& t)
+{
+      return t.x1()    * (t.x2()*t.x3()    - t.x4()*t.x4()/two) -
+             t.x6()/r2 * (t.x3()*t.x6()/r2 - t.x4()*t.x5()/two) +
+             t.x5()/r2 * (t.x6()*t.x4()/two - t.x2()*t.x5()/r2);
+}
+
+//inverse
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+mandel6x1<T> Inverse(
+    mandel6x1<T> const &V)
+{
+    //Direct calculation of inverse of (6x1) 2nd-order Mandel tensor 
+    mandel6x1<T> u;
+    T inv_det = 0.0;
+    T det = Det(V);
+
+    u.x1() = (V.x2()*V.x3()    - V.x4()*V.x4()/two)*inv_det;
+    u.x2() = (V.x1()*V.x3()    - V.x5()*V.x5()/two)*inv_det;
+    u.x3() = (V.x1()*V.x2()    - V.x6()*V.x6()/two)*inv_det;
+    u.x4() = (V.x6()*V.x5()/two - V.x1()*V.x4()/r2)*inv_det;
+    u.x5() = (V.x6()*V.x4()/two - V.x2()*V.x5()/r2)*inv_det;
+    u.x6() = (V.x4()*V.x5()/two - V.x6()*V.x3()/r2)*inv_det;
+    //not in mandel form anymore; return to mandel form for consistency with 
+    //other functions
+    u.MandelXform();
+    return u;
+}
+
+/** Tensor multiply MandelVector (6x1) by MandelVector (6x1) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x1<T> const &v,
+    mandel6x1<U> const &t)
+{
+    mandel6x1<T> tt = t;
+    mandel6x1<U> vv = v;
+    tt.invMandelXform();
+    vv.invMandelXform();
+
+    using result_type decltype(v.xx() * t.xx());
+    return mandel6x1<result_type>(
+          tt.x1()*vv.x1()+tt.x6()*vv.x6()+tt.x5()*vv.x5(),
+          tt.x6()*vv.x6()+tt.x2()*vv.x2()+tt.x4()*vv.x4(),
+          tt.x5()*vv.x5()+tt.x4()*vv.x4()+tt.x3()*vv.x3(),
+          tt.x6()*vv.x5()+tt.x2()*vv.x4()+tt.x4()*vv.x3(),
+          tt.x1()*vv.x5()+tt.x6()*vv.x4()+tt.x5()*vv.x3(),
+          tt.x1()*vv.x6()+tt.x6()*vv.x2()+tt.x5()*vv.x4(),
+          true);
+}
+
+/** Tensor multiply MandelVector (6x1) by symmetric3x3 (3x3) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x1<T> const &v, 
+    symmetric3x3<U> const &tt)
+{
+    MandelVector<T> vv = v;
+    vv.invMandelXform();
+
+    using result_type = decltype(tt.xx() * v.xx());
+    return mandel6x1<result_type>(
+          tt.xx()*vv.x1()+tt.xy()*vv.x6()+tt.xz()*vv.x5(),
+          tt.xy()*vv.x6()+tt.yy()*vv.x2()+tt.yz()*vv.x4(),
+          tt.xz()*vv.x5()+tt.yz()*vv.x4()+tt.zz()*vv.x3(),
+          tt.xy()*vv.x5()+tt.yy()*vv.x4()+tt.yz()*vv.x3(),
+          tt.xx()*vv.x5()+tt.xy()*vv.x4()+tt.xz()*vv.x3(),
+          tt.xx()*vv.x6()+tt.xy()*vv.x2()+tt.xz()*vv.x4(),
+          true);
+}
+
+/** Tensor multiply symmetric3x3 by MandelVector (6x1) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    symmetric3x3<T> const &tt)
+    mandel6x1<U> const &v, 
+{
+    mandel6x1<U> vv = v;
+    vv.invMandelXform();
+
+    using result_type = decltype(tt.xx() * v.xx());
+    return mandel6x1<result_type>(
+          tt.xx()*vv.x1()+tt.xy()*vv.x6()+tt.xz()*vv.x5(),
+          tt.xy()*vv.x6()+tt.yy()*vv.x2()+tt.yz()*vv.x4(),
+          tt.xz()*vv.x5()+tt.yz()*vv.x4()+tt.zz()*vv.x3(),
+          tt.xy()*vv.x5()+tt.yy()*vv.x4()+tt.yz()*vv.x3(),
+          tt.xx()*vv.x5()+tt.xy()*vv.x4()+tt.xz()*vv.x3(),
+          tt.xx()*vv.x6()+tt.xy()*vv.x2()+tt.xz()*vv.x4(),
+          true);
+}
+
+/** Tensor multiply MandelVector (6x1) by diagonal3x3 (3x3) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(mandel6x1<T> const &v, diagonal3x3<U> const &tt)
+{
+    mandel6x1<T> vv = v;
+    vv.invMandelXform();
+
+    using result_type = decltype(tt.xx() * v.xx());
+    return mandel6x1<result_type>(
+          tt.xx()*vv.x1(),
+          tt.yy()*vv.x2(),
+          tt.zz()*vv.x3(),
+          tt.yy()*vv.x4(),
+          tt.xx()*vv.x5(),
+          tt.xx()*vv.x6(),
+          true);
+}
+
+/** Tensor multiply diagonal3x3 (3x3) by MandelVector (6x1) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(diagonal3x3<T> const &tt, mandel6x1<U> const &v)
+{
+    mandel6x1<U> vv = v;
+    vv.invMandelXform();
+
+    using result_type = decltype(tt.xx() * v.xx());
+    return mandel6x1<result_type>(
+          tt.xx()*vv.x1(),
+          tt.yy()*vv.x2(),
+          tt.zz()*vv.x3(),
+          tt.yy()*vv.x4(),
+          tt.xx()*vv.x5(),
+          tt.xx()*vv.x6(),
+          true);
+}
+
+/** Tensor multiply MandelVector (6x1) by vector3 (3x1) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(mandel6x1<T> const &m, vector3<U> const &v)
+{
+  mandel6x1<T> t = m;
+  t.invMandelXform();
+  //The transformation is reversed as the operation is performed 
+  // by first converting to a tensor.
+  using result_type = decltype(t.xx() * v.x());
+  return vector3<result_type>(
+          t.x1()*v.x() + t.x6()*v.y() + t.x5()*v.z(),
+          t.x6()*v.x() + t.x2()*v.y() + t.x4()*v.z(),
+          t.x5()*v.x() + t.x4()*v.y() + t.x3()*v.z());
+}
+
+//partial pivoting in <dynamic_matrix.hpp>
+
+//////////////////////////////////////////////////////////////////////////////////
+// Operations Yielding Scalars (double dot product of two tensors (2nd order)
+//////////////////////////////////////////////////////////////////////////////////
+//double dot product of mandel6x1 with mandel6x1
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto ddot(mandel6x1<T> const &t, mandel6x1<U> const &v)
+{
+    using result_type = decltype(t.x1() * v.x());
+    return result_type(t.x1()*v.x1() + t.x2()*v.x2() + t.x3()*v.x3() + two*t.x4()*v.x4() + two*t.x5()*v.x5() + two*t.x6()*v.x6());
+}
+
+//double dot product of mandel6x1 with diagonal3x3
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto ddot(mandel6x1<T> const &t, diagonal3x3<U> const &d)
+{
+    using result_type = decltype(t.x1() * d.x());
+    return result_type(t.x1()*d.xx() + t.x2()*d.yy() + t.x3()*d.zz());
+}
+
+//double dot product of diagonal3x3 and mandel6x1
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto ddot(diagonal3x3<T> const &d, mandel6x1<U> const &t)
+{
+    using result_type = decltype(d.xx() * t.x1());
+    return result_type(t.x1()*d.xx() + t.x2()*d.yy() + t.x3()*d.zz());
+}
+
+//double dot product of mandel6x1 and symmetric3x3
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto ddot( mandel6x1<T> const &v, symmetric3x3<U> const &t)
+{
+    using result_type = decltype(v.x1() * t.xx());
+    return result_type(t.xx()*v.x1() + t.yy()*v.x2() + t.zz()*v.x3() + two*t.yz()*v.x4() + two*t.xz()*v.x5() + two*t.xy()*v.x6());
+}
+
+//double dot product of symmetric3x3 and mandel6x1
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto ddot(symmetric3x3<T> const& t, mandel6x1<U> const &v) 
+{
+    using result_type = decltype(v.x1() * t.xx());
+    return result_type(t.xx()*v.x1() + t.yy()*v.x2() + t.zz()*v.x3() + two*t.yz()*v.x4() + two*t.xz()*v.x5() + two*t.xy()*v.x6());
+}
+
+//double dot product of mandel6x1 and matrix3x3
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto ddot(mandel6x1<T> const& v, matrix3x3<U> const& t)
+{
+    using result_type = decltype(t.xx() * v.x1());
+    return result_type(t.xx()*v.x1() + t.yy()*v.x2() + t.zz()*v.x3() + t.yz()*v.x4() + t.xz()*v.x5() + t.xy()*v.x6() + t.zy()*v.x4() + t.zx()*v.x5() + t.yx()*v.x6());
+}
+
+//double dot product of matrix3x3 and mandel6x1 
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto ddot(matrix3x3<T> const& t, mandel6x1<U> const& v)
+{
+    using result_type = decltype(v.x1() * t.xx());
+    return result_type(t.xx()*v.x1() + t.yy()*v.x2() + t.zz()*v.x3() + t.yz()*v.x4() + t.xz()*v.x5() + t.xy()*v.x6() + t.zy()*v.x4() + t.zx()*v.x5() + t.yx()*v.x6());
+}
+//////////////////////////////////////////////////////////////////////////////////
+// Operations Yielding matrix3x3
+//////////////////////////////////////////////////////////////////////////////////
+/** Tensor mult: mandel6x1 by matrix3x3 **/ 
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(mandel6x1<T> const& v, matrix3x3<U> const& t)
+{ 
+    using result_type = decltype(t.xx() * v.x1());
+    //The transformation is reversed as the operation is performed 
+    // by first converting to a tensor.
+    return matrix3x3<result_type>(v.x1()*t.xx()+v.x6()/r2*t.yx()+v.x5()/r2*t.zx(),v.x1()*t.xy()+v.x6()/r2*t.yy()+v.x5()/r2*t.zy(),v.x1()*t.xz()+v.x6()/r2*t.yz()+v.x5()/r2*t.zz(),
+                       v.x6()/r2*t.xx()+v.x2()*t.yx()+v.x4()/r2*t.zx(),v.x6()/r2*t.xy()+v.x2()*t.yy()+v.x4()/r2*t.zy(),v.x6()/r2*t.xz()+v.x2()*t.yz()+v.x4()/r2*t.zz(),
+                       v.x5()/r2*t.xx()+v.x4()/r2*t.yx()+v.x3()*t.zx(),v.x5()/r2*t.xy()+v.x4()/r2*t.yy()+v.x3()*t.zy(),v.x5()/r2*t.xz()+v.x4()/r2*t.yz()+v.x3()*t.zz());
+}
+
+/** Tensor mult: matrix3x3 by mandel6x1 **/ 
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(matrix3x3<T> const& t, mandel6x1<U> const& v)
+{ 
+    //The transformation is reversed as the operation is performed 
+    // by first converting to a tensor.
+    using result_type = decltype(t.xx() * v.x1());
+    return matrix3x3<result_type>(t.xx()*v.x1()+t.xy()*v.x6()/r2+t.xz()*v.x5()/r2,t.xx()*v.x6()/r2+t.xy()*v.x2()+t.xz()*v.x4()/r2,t.xx()*v.x5()/r2+t.xy()*v.x4()/r2+t.xz()*v.x3(),
+                  t.yx()*v.x1()+t.yy()*v.x6()/r2+t.yz()*v.x5()/r2,t.yx()*v.x6()/r2+t.yy()*v.x2()+t.yz()*v.x4()/r2,t.yx()*v.x5()/r2+t.yy()*v.x4()/r2+t.yz()*v.x3(),
+                  t.zx()*v.x1()+t.zy()*v.x6()/r2+t.zz()*v.x5()/r2,t.zx()*v.x6()/r2+t.zy()*v.x2()+t.zz()*v.x4()/r2,t.zx()*v.x5()/r2+t.zy()*v.x4()/r2+t.zz()*v.x3());
+}
+
+//////////////////////////////////////////////////////////////////////////////////
+// Operations Yielding symmetric3x3 from a mandel6x1 
+//////////////////////////////////////////////////////////////////////////////////
+
+/** Convert MandelVector (6x1) to symmetric3x3 **/
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+symmetric3x3<T> mandel6x1_to_symmetric3x3(mandel6x1<T> const& v)
+{
+    //invert Mandel Tranformation of MandelVector 
+    return symmetric3x3<T>(v.x1(),v.x6()/r2,v.x5()/r2,
+                                  v.x2()   ,v.x4()/r2,
+                                            v.x3());
+}
+
+//misc
+inline int constexpr mandel6x1_component_count = 6;
+

--- a/p3a_mandel6x1.hpp
+++ b/p3a_mandel6x1.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "p3a_scalar.hpp"
 #include "p3a_macros.hpp"
 #include "p3a_functions.hpp"
 #include "p3a_diagonal3x3.hpp"
@@ -69,7 +70,7 @@
  * transformation must be applied manually by applying the method `MandelXform()` 
  * method to the Mandel-type object. The transform will be contained in any result 
  * returning a Mandel-type object. This means that the Mandel transformation must be 
- * inverted when converting MandelVectors (6-element symmetric tensors) to full 
+ * inverted when converting mandel6x1 (6-element symmetric tensors) to full 
  * 9-element (3x3) 2<sup>nd</sup>-order tensors. 
  *
  * This library automatically inverts the Mandel transformation when returning a
@@ -85,22 +86,18 @@ namespace p3a {
 /******************************************************************/
 /******************************************************************/
 template <class T>
-class Mandel6x1
+class mandel6x1
 /** 
  * Represents a 2nd order tensor as a 6x1 Mandel array
  */
 /******************************************************************/
 {
- T x1,x2,x3,x4,x5,x6;
+ T m_x1,m_x2,m_x3,m_x4,m_x5,m_x6;
  bool applyTransform;
 
- template<class T>
- P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static
- T r2() {std::sqrt(T(2.0));}
+ static const T r2 = square_root(T(2.0));
 
- template<class T>
- P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static 
- T two() {T(2.0);}
+ static const T two= T(2.0);
 
  public:
   /**** constructors, destructors, and assigns ****/
@@ -111,12 +108,12 @@ class Mandel6x1
   mandel6x1(
       T const& X1, T const& X2, T const& X3,
       T const& X4, T const& X5, T const& X6):
-       x1(X1),
-       x2(X2),
-       x3(X3),
-       x4(X4),
-       x5(X5),
-       x6(X6),
+       m_x1(X1),
+       m_x2(X2),
+       m_x3(X3),
+       m_x4(X4),
+       m_x5(X5),
+       m_x6(X6),
        applyTransform(true)
   {
     this->MandelXform();
@@ -126,12 +123,12 @@ class Mandel6x1
   mandel6x1(
       T const& X1, T const& X2, T const& X3,
       T const& X4, T const& X5, T const& X6, bool const& Xform)
-    :x1(X1)
-    ,x2(X2)
-    ,x3(X3)
-    ,x4(X4)
-    ,x5(X5)
-    ,x6(X6)
+    :m_x1(X1)
+    ,m_x2(X2)
+    ,m_x3(X3)
+    ,m_x4(X4)
+    ,m_x5(X5)
+    ,m_x6(X6)
     ,applyTransform(Xform)
   {
     if (applyTransform)
@@ -140,26 +137,25 @@ class Mandel6x1
 
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   mandel6x1(symmetric3x3<T> const& a):
-    x1(a.xx()),
-    x2(a.yy()),
-    x3(a.zz()),
-    x4(a.yz()),
-    x5(a.xz()),
-    x6(a.xy()),
+    m_x1(a.xx()),
+    m_x2(a.yy()),
+    m_x3(a.zz()),
+    m_x4(a.yz()),
+    m_x5(a.xz()),
+    m_x6(a.xy()),
     applyTransform(true)
   {
-    if (applyTransform)
-        this->MandelXform();
+    this->MandelXform();
   }
 
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   mandel6x1(symmetric3x3<T> const& a, bool const& Xform):
-    x1(a.xx()),
-    x2(a.yy()),
-    x3(a.zz()),
-    x4(a.yz()),
-    x5(a.xz()),
-    x6(a.xy()),
+    m_x1(a.xx()),
+    m_x2(a.yy()),
+    m_x3(a.zz()),
+    m_x4(a.yz()),
+    m_x5(a.xz()),
+    m_x6(a.xy()),
     applyTransform(Xform)
   {
     if (applyTransform)
@@ -168,12 +164,12 @@ class Mandel6x1
 
   P3A_NEVER_INLINE
   mandel6x1(matrix3x3<T> const& a):
-    x1(a.xx()),
-    x2(a.yy()),
-    x3(a.zz()),
-    x4(a.yz()),
-    x5(a.xz()),
-    x6(a.xy()),
+    m_x1(a.xx()),
+    m_x2(a.yy()),
+    m_x3(a.zz()),
+    m_x4(a.yz()),
+    m_x5(a.xz()),
+    m_x6(a.xy()),
     applyTransform(true)
   {
     if(compare(a.yz(),a.zy()) && compare(a.zx(),a.xz()) && compare(a.xy(),a.yx()))
@@ -184,12 +180,12 @@ class Mandel6x1
 
   P3A_NEVER_INLINE
   mandel6x1(matrix3x3<T> const& a, bool const& Xform):
-    x1(a.xx()),
-    x2(a.yy()),
-    x3(a.zz()),
-    x4(a.yz()),
-    x5(a.xz()),
-    x6(a.xy()),
+    m_x1(a.xx()),
+    m_x2(a.yy()),
+    m_x3(a.zz()),
+    m_x4(a.yz()),
+    m_x5(a.xz()),
+    m_x6(a.xy()),
     applyTransform(Xform)
   {
     if(compare(a.yz(),a.zy()) && compare(a.zx(),a.xz()) && compare(a.xy(),a.yx()))
@@ -201,12 +197,12 @@ class Mandel6x1
 
   P3A_NEVER_INLINE
   mandel6x1(static_matrix<T,3,3> const& a, bool const& Xform):
-    x1(a(0,0)),
-    x2(a(1,1)),
-    x3(a(2,2)),
-    x4(a(1,2)),
-    x5(a(0,2)),
-    x6(a(0,1)),
+    m_x1(a(0,0)),
+    m_x2(a(1,1)),
+    m_x3(a(2,2)),
+    m_x4(a(1,2)),
+    m_x5(a(0,2)),
+    m_x6(a(0,1)),
     applyTransform(Xform)
   {
     if(compare(a(1,2),a(2,1)) && compare(a(0,2),a(2,0)) && compare(a(0,1),a(1,0)))
@@ -219,12 +215,12 @@ class Mandel6x1
 
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   mandel6x1(diagonal3x3<T> const& a):
-    x1(a.xx()),
-    x2(a.yy()),
-    x3(a.zz()),
-    x4(T(0.0)),
-    x5(T(0.0)),
-    x6(T(0.0)),
+    m_x1(a.xx()),
+    m_x2(a.yy()),
+    m_x3(a.zz()),
+    m_x4(T(0.0)),
+    m_x5(T(0.0)),
+    m_x6(T(0.0)),
     applyTransform(true)
   {
     this->MandelXform();
@@ -232,12 +228,12 @@ class Mandel6x1
 
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   mandel6x1(diagonal3x3<T> const& a, bool const& Xform):
-    x1(a.xx()),
-    x2(a.yy()),
-    x3(a.zz()),
-    x4(T(0.0)),
-    x5(T(0.0)),
-    x6(T(0.0)),
+    m_x1(a.xx()),
+    m_x2(a.yy()),
+    m_x3(a.zz()),
+    m_x4(T(0.0)),
+    m_x5(T(0.0)),
+    m_x6(T(0.0)),
     applyTransform(Xform)
   {
       if(applyTransform)
@@ -245,59 +241,59 @@ class Mandel6x1
   }
   //Return components by ij descriptor
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& xx() const { return x1; }
+  T const& xx() const { return m_x1; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& yy() const { return x2; }
+  T const& yy() const { return m_x2; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& zz() const { return x3; }
+  T const& zz() const { return m_x3; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& yz() const { return x4; }
+  T const& yz() const { return m_x4; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& xz() const { return x5; }
+  T const& xz() const { return m_x5; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& xy() const { return x6; }
+  T const& xy() const { return m_x6; }
 
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& xx() { return x1; }
+  T& xx() { return m_x1; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& yy() { return x2; }
+  T& yy() { return m_x2; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& zz() { return x3; }
+  T& zz() { return m_x3; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& yz() { return x4; }
+  T& yz() { return m_x4; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& xz() { return x5; }
+  T& xz() { return m_x5; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& xy() { return x6; }
+  T& xy() { return m_x6; }
 
   //return by mandel index 1-6
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x1() const { return x1; }
+  T const& x1() const { return m_x1; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x2() const { return x2; }
+  T const& x2() const { return m_x2; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x3() const { return x3; }
+  T const& x3() const { return m_x3; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x4() const { return x4; }
+  T const& x4() const { return m_x4; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x5() const { return x5; }
+  T const& x5() const { return m_x5; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x6() const { return x6; }
+  T const& x6() const { return m_x6; }
 
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x1() { return x1; }
+  T& x1() { return m_x1; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x2() { return x2; }
+  T& x2() { return m_x2; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x3() { return x3; }
+  T& x3() { return m_x3; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x4() { return x4; }
+  T& x4() { return m_x4; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x5() { return x5; }
+  T& x5() { return m_x5; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x6() { return x6; }
+  T& x6() { return m_x6; }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
   mandel6x1<T> zero()
   {
     return mandel6x1<T>(
@@ -305,7 +301,7 @@ class Mandel6x1
         T(0), T(0), T(0),false);
   }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
   mandel6x1<T> identity()
   {
     return mandel6x1<T>(
@@ -313,20 +309,66 @@ class Mandel6x1
         T(0), T(0), T(0),true);
   }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   void MandelXform()
   {
-      x4 *= r2;
-      x5 *= r2;
-      x6 *= r2;
+      m_x4 *= r2;
+      m_x5 *= r2;
+      m_x6 *= r2;
   }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   void invMandelXform()
   {
-      x4 /= r2;
-      x5 /= r2;
-      x6 /= r2;
+      m_x4 /= r2;
+      m_x5 /= r2;
+      m_x6 /= r2;
+  }
+
+  //conversion of symmetric3x3 to mandel6x1 via assignment
+  template <class U>
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x1<U> operator=(
+      symmetric3x3<U> const& t)
+  {
+      return mandel6x1<U>(
+              t.xx(),
+              t.yy(),
+              t.zz(),
+              t.yz(),
+              t.xz(),
+              t.xy(),
+              true);
+  }
+
+  //conversion of mandel6x1 to symmetric3x3 via assignment
+  template <class U>
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  symmetric3x3<U> operator=(
+      mandel6x1<U> const& tt)
+  {
+      mandel6x1<T> t = tt;
+      t.invMandelXform();
+
+      return symmetric3x3<U>(
+              t.x1(), t.x6(), t.x5(),
+                      t.x2(), t.x4(),
+                              t.x3());
+  }
+
+  //conversion to matrix3x3 via assignment
+  template <class U>
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  matrix3x3<U> operator=(
+      mandel6x1<U> const& tt)
+  {
+      mandel6x1<U> t = tt;
+      t.invMandelXform();
+
+      return matrix3x3<U>(
+              t.x1(), t.x6(), t.x5(),
+              t.x6(), t.x2(), t.x4(),
+              t.x5(), t.x4(), t.x3());
   }
 
 };
@@ -334,51 +376,6 @@ class Mandel6x1
 /***************************************************************************** 
  * Operators overloads for mandel6x1 tensors (2nd order tensor)
  *****************************************************************************/
-//conversion of symmetric3x3 to mande6x1 via assignment
-template <class T>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-auto operator=(
-    symmetric3x3<T> const& t)
-{
-    return mandel6x1<T>(
-            t.xx(),
-            t.yy(),
-            t.zz(),
-            t.yz(),
-            t.xz(),
-            t.xy(),
-            true);
-}
-
-//conversion of mandel6x1 to symmetric3x3 via assignment
-template <class T>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-symmetric3x3<T> operator=(
-    madel6x1<T> const& tt)
-{
-    mandel6x1<T> t = tt;
-    t.invMandelXform();
-
-    return symmetric3x3<T>(
-            t.x1(), t.x6(), t.x5(),
-                    t.x2(), t.x4(),
-                            t.x3());
-}
-
-//conversion to matrix3x3 via assignment
-template <class T>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-matrix3x3<T> operator=(
-    madel6x1<T> const& tt)
-{
-    mandel6x1<T> t = tt;
-    t.invMandelXform();
-
-    return matrix3x3<T>(
-            t.x1(), t.x6(), t.x5(),
-            t.x6(), t.x2(), t.x4(),
-            t.x5(), t.x4(), t.x3());
-}
 
 
 //mandel6x1 binary operators with scalars
@@ -391,18 +388,18 @@ operator*(
     B const& c)
 {
     return mandel6x1<decltype(t.x1()*c)>(
-            a.x1()*c,
-            a.x2()*c,
-            a.x3()*c,
-            a.x4()*c,
-            a.x5()*c,
-            a.x6()*c,
+            t.x1()*c,
+            t.x2()*c,
+            t.x3()*c,
+            t.x4()*c,
+            t.x5()*c,
+            t.x6()*c,
             false);
 }
 
 //multiplication by constant
 template <class A, class B>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexp, 
 typename std::enable_if<is_scalar<A>, mandel6x1<decltype(A() * B())>>::type 
 operator*(
     A const& c, 
@@ -414,12 +411,12 @@ operator*(
 //division by constant
 template <class A, class B>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-typename std::enable_if<is_scalar<B>, mandel6x1<decltype(A() * B())>>::type
+typename std::enable_if<is_scalar<B>, mandel6x1<decltype(A() * B())>>::type 
 operator/(
     mandel6x1<A> const& t, 
     B const& c)
 {
-    return mandel6x1<decltype<(t.x1() / c)>(
+    return mandel6x1<decltype(A() * B())>(
             t.x1() / c,
             t.x2() / c,
             t.x3() / c,
@@ -431,7 +428,7 @@ operator/(
 
 //multiplication *= by constant
 template <class A>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator*=(
     mandel6x1<A>& t, 
     A const& c)
@@ -446,7 +443,7 @@ void operator*=(
 
 //division /= by constant
 template <class A>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator/=(
     mandel6x1<A>& t, 
     A const& c)
@@ -461,7 +458,7 @@ void operator/=(
 
 //mandel6x1 -= subtraction
 template <class T>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator-=(
     mandel6x1<T>& a, 
     mandel6x1<T> const& b)
@@ -482,8 +479,7 @@ mandel6x1<T> operator+(
     mandel6x1<T> const& a, 
     mandel6x1<U> const& b)
 {
-  using result_type (a.x11*b.x12)
-  return mandel6x1<result_type>(
+  return mandel6x1<decltype(a.x11*b.x12)>(
     a.x1() + b.x1(),
     a.x2() + b.x2(),
     a.x3() + b.x3(),
@@ -495,7 +491,7 @@ mandel6x1<T> operator+(
 
 //mandel6x1 += addition
 template <class T>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator+=(
     mandel6x1<T>& a, 
     mandel6x1<T> const& b)
@@ -542,7 +538,7 @@ mandel6x1<T> operator-(
 }
 
 /***************************************************************************** 
- * Linear Algebra for MandelVector (2nd order tensor)
+ * Linear Algebra for Mandel6x1 (2nd order tensor)
  *****************************************************************************/
 //trace
 template <class T>
@@ -559,9 +555,9 @@ template <class T>
 T Det(
     mandel6x1<T> const& t)
 {
-      return t.x1()    * (t.x2()*t.x3()    - t.x4()*t.x4()/two<T>()) -
-             t.x6()/r2<T>() * (t.x3()*t.x6()/r2<T>() - t.x4()*t.x5()/two<T>()) +
-             t.x5()/r2<T>() * (t.x6()*t.x4()/two<T>() - t.x2()*t.x5()/r2<T>());
+      return t.x1()    * (t.x2()*t.x3()    - t.x4()*t.x4()/t.two) -
+             t.x6()/t.r2 * (t.x3()*t.x6()/t.r2 - t.x4()*t.x5()/t.two) +
+             t.x5()/t.r2 * (t.x6()*t.x4()/t.two - t.x2()*t.x5()/t.r2);
 }
 
 //inverse
@@ -575,12 +571,12 @@ mandel6x1<T> Inverse(
     T inv_det = 0.0;
     T det = Det(V);
 
-    u.x1() = (V.x2()*V.x3()    - V.x4()*V.x4()/two<T>())*inv_det;
-    u.x2() = (V.x1()*V.x3()    - V.x5()*V.x5()/two<T>())*inv_det;
-    u.x3() = (V.x1()*V.x2()    - V.x6()*V.x6()/two<T>())*inv_det;
-    u.x4() = (V.x6()*V.x5()/two<T>() - V.x1()*V.x4()/r2<T>())*inv_det;
-    u.x5() = (V.x6()*V.x4()/two<T>() - V.x2()*V.x5()/r2<T>())*inv_det;
-    u.x6() = (V.x4()*V.x5()/two<T>() - V.x6()*V.x3()/r2<T>())*inv_det;
+    u.x1() = (V.x2()*V.x3()    - V.x4()*V.x4()/V.two)*inv_det;
+    u.x2() = (V.x1()*V.x3()    - V.x5()*V.x5()/V.two)*inv_det;
+    u.x3() = (V.x1()*V.x2()    - V.x6()*V.x6()/V.two)*inv_det;
+    u.x4() = (V.x6()*V.x5()/V.two - V.x1()*V.x4()/V.r2)*inv_det;
+    u.x5() = (V.x6()*V.x4()/V.two - V.x2()*V.x5()/V.r2)*inv_det;
+    u.x6() = (V.x4()*V.x5()/V.two - V.x6()*V.x3()/V.r2)*inv_det;
     //not in mandel form anymore; return to mandel form for consistency with 
     //other functions
     u.MandelXform();
@@ -599,7 +595,7 @@ auto operator*(
     tt.invMandelXform();
     vv.invMandelXform();
 
-    using result_type decltype(v.xx() * t.xx());
+    using result_type = decltype(v.xx() * t.xx());
     return mandel6x1<result_type>(
           tt.x1()*vv.x1()+tt.x6()*vv.x6()+tt.x5()*vv.x5(),
           tt.x6()*vv.x6()+tt.x2()*vv.x2()+tt.x4()*vv.x4(),
@@ -617,7 +613,7 @@ auto operator*(
     mandel6x1<T> const &v, 
     symmetric3x3<U> const &tt)
 {
-    MandelVector<T> vv = v;
+    mandel6x1<T> vv = v;
     vv.invMandelXform();
 
     using result_type = decltype(tt.xx() * v.xx());
@@ -635,8 +631,8 @@ auto operator*(
 template <class T, class U>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 auto operator*(
-    symmetric3x3<T> const &tt)
-    mandel6x1<U> const &v, 
+    symmetric3x3<T> const &tt,
+    mandel6x1<U> const &v) 
 {
     mandel6x1<U> vv = v;
     vv.invMandelXform();
@@ -717,7 +713,7 @@ template <class T, class U>
 auto ddot(mandel6x1<T> const &t, mandel6x1<U> const &v)
 {
     using result_type = decltype(t.x1() * v.x());
-    return result_type(t.x1()*v.x1() + t.x2()*v.x2() + t.x3()*v.x3() + two<T>()*t.x4()*v.x4() + two<T>()*t.x5()*v.x5() + two<T>()*t.x6()*v.x6());
+    return result_type(t.x1()*v.x1() + t.x2()*v.x2() + t.x3()*v.x3() + t.two*t.x4()*v.x4() + t.two*t.x5()*v.x5() + t.two*t.x6()*v.x6());
 }
 
 //double dot product of mandel6x1 with diagonal3x3
@@ -744,7 +740,7 @@ template <class T, class U>
 auto ddot( mandel6x1<T> const &v, symmetric3x3<U> const &t)
 {
     using result_type = decltype(v.x1() * t.xx());
-    return result_type(t.xx()*v.x1() + t.yy()*v.x2() + t.zz()*v.x3() + two<T>()*t.yz()*v.x4() + two<T>()*t.xz()*v.x5() + two<T>()*t.xy()*v.x6());
+    return result_type(t.xx()*v.x1() + t.yy()*v.x2() + t.zz()*v.x3() + v.two*t.yz()*v.x4() + v.two*t.xz()*v.x5() + v.two*t.xy()*v.x6());
 }
 
 //double dot product of symmetric3x3 and mandel6x1
@@ -753,7 +749,7 @@ template <class T, class U>
 auto ddot(symmetric3x3<T> const& t, mandel6x1<U> const &v) 
 {
     using result_type = decltype(v.x1() * t.xx());
-    return result_type(t.xx()*v.x1() + t.yy()*v.x2() + t.zz()*v.x3() + two<T>()*t.yz()*v.x4() + two<T>()*t.xz()*v.x5() + two<T>()*t.xy()*v.x6());
+    return result_type(t.xx()*v.x1() + t.yy()*v.x2() + t.zz()*v.x3() + v.two*t.yz()*v.x4() + v.two*t.xz()*v.x5() + v.two*t.xy()*v.x6());
 }
 
 //double dot product of mandel6x1 and matrix3x3
@@ -784,9 +780,9 @@ auto operator*(mandel6x1<T> const& v, matrix3x3<U> const& t)
     using result_type = decltype(t.xx() * v.x1());
     //The transformation is reversed as the operation is performed 
     // by first converting to a tensor.
-    return matrix3x3<result_type>(v.x1()*t.xx()+v.x6()/r2<T>()*t.yx()+v.x5()/r2<T>()*t.zx(),v.x1()*t.xy()+v.x6()/r2<T>()*t.yy()+v.x5()/r2<T>()*t.zy(),v.x1()*t.xz()+v.x6()/r2<T>()*t.yz()+v.x5()/r2<T>()*t.zz(),
-                       v.x6()/r2<T>()*t.xx()+v.x2()*t.yx()+v.x4()/r2<T>()*t.zx(),v.x6()/r2<T>()*t.xy()+v.x2()*t.yy()+v.x4()/r2<T>()*t.zy(),v.x6()/r2<T>()*t.xz()+v.x2()*t.yz()+v.x4()/r2<T>()*t.zz(),
-                       v.x5()/r2<T>()*t.xx()+v.x4()/r2<T>()*t.yx()+v.x3()*t.zx(),v.x5()/r2<T>()*t.xy()+v.x4()/r2<T>()*t.yy()+v.x3()*t.zy(),v.x5()/r2<T>()*t.xz()+v.x4()/r2<T>()*t.yz()+v.x3()*t.zz());
+    return matrix3x3<result_type>(v.x1()*t.xx()+v.x6()/v.r2*t.yx()+v.x5()/v.r2*t.zx(),v.x1()*t.xy()+v.x6()/v.r2*t.yy()+v.x5()/v.r2*t.zy(),v.x1()*t.xz()+v.x6()/v.r2*t.yz()+v.x5()/v.r2*t.zz(),
+                       v.x6()/v.r2*t.xx()+v.x2()*t.yx()+v.x4()/v.r2*t.zx(),v.x6()/v.r2*t.xy()+v.x2()*t.yy()+v.x4()/v.r2*t.zy(),v.x6()/v.r2*t.xz()+v.x2()*t.yz()+v.x4()/v.r2*t.zz(),
+                       v.x5()/v.r2*t.xx()+v.x4()/v.r2*t.yx()+v.x3()*t.zx(),v.x5()/v.r2*t.xy()+v.x4()/v.r2*t.yy()+v.x3()*t.zy(),v.x5()/v.r2*t.xz()+v.x4()/v.r2*t.yz()+v.x3()*t.zz());
 }
 
 /** Tensor mult: matrix3x3 by mandel6x1 **/ 
@@ -797,9 +793,9 @@ auto operator*(matrix3x3<T> const& t, mandel6x1<U> const& v)
     //The transformation is reversed as the operation is performed 
     // by first converting to a tensor.
     using result_type = decltype(t.xx() * v.x1());
-    return matrix3x3<result_type>(t.xx()*v.x1()+t.xy()*v.x6()/r2<T>()+t.xz()*v.x5()/r2<T>(),t.xx()*v.x6()/r2<T>()+t.xy()*v.x2()+t.xz()*v.x4()/r2<T>(),t.xx()*v.x5()/r2<T>()+t.xy()*v.x4()/r2<T>()+t.xz()*v.x3(),
-                  t.yx()*v.x1()+t.yy()*v.x6()/r2<T>()+t.yz()*v.x5()/r2<T>(),t.yx()*v.x6()/r2<T>()+t.yy()*v.x2()+t.yz()*v.x4()/r2<T>(),t.yx()*v.x5()/r2<T>()+t.yy()*v.x4()/r2<T>()+t.yz()*v.x3(),
-                  t.zx()*v.x1()+t.zy()*v.x6()/r2<T>()+t.zz()*v.x5()/r2<T>(),t.zx()*v.x6()/r2<T>()+t.zy()*v.x2()+t.zz()*v.x4()/r2<T>(),t.zx()*v.x5()/r2<T>()+t.zy()*v.x4()/r2<T>()+t.zz()*v.x3());
+    return matrix3x3<result_type>(t.xx()*v.x1()+t.xy()*v.x6()/v.r2+t.xz()*v.x5()/v.r2,t.xx()*v.x6()/v.r2+t.xy()*v.x2()+t.xz()*v.x4()/v.r2,t.xx()*v.x5()/v.r2+t.xy()*v.x4()/v.r2+t.xz()*v.x3(),
+                  t.yx()*v.x1()+t.yy()*v.x6()/v.r2+t.yz()*v.x5()/v.r2,t.yx()*v.x6()/v.r2+t.yy()*v.x2()+t.yz()*v.x4()/v.r2,t.yx()*v.x5()/v.r2+t.yy()*v.x4()/v.r2+t.yz()*v.x3(),
+                  t.zx()*v.x1()+t.zy()*v.x6()/v.r2+t.zz()*v.x5()/v.r2,t.zx()*v.x6()/v.r2+t.zy()*v.x2()+t.zz()*v.x4()/v.r2,t.zx()*v.x5()/v.r2+t.zy()*v.x4()/v.r2+t.zz()*v.x3());
 }
 
 //////////////////////////////////////////////////////////////////////////////////
@@ -812,11 +808,12 @@ template <class T>
 symmetric3x3<T> mandel6x1_to_symmetric3x3(mandel6x1<T> const& v)
 {
     //invert Mandel Tranformation of MandelVector 
-    return symmetric3x3<T>(v.x1(),v.x6()/r2<T>(),v.x5()/r2<T>(),
-                                  v.x2()   ,v.x4()/r2<T>(),
+    return symmetric3x3<T>(v.x1(),v.x6()/v.r2,v.x5()/v.r2,
+                                  v.x2()   ,v.x4()/v.r2,
                                             v.x3());
 }
 
 //misc
 inline int constexpr mandel6x1_component_count = 6;
 
+}

--- a/p3a_mandel6x3.hpp
+++ b/p3a_mandel6x3.hpp
@@ -27,31 +27,25 @@ namespace p3a {
 /******************************************************************/
 /******************************************************************/
 template <class T>
-class Mandel6x3
+class mandel6x3
 /** 
  * Represents a 3th order tensor as a 6x3 Mandel array
  */
 /******************************************************************/
 {
- T x11,x12,x13,
-   x21,x22,x23,
-   x31,x32,x33,
-   x41,x42,x43,
-   x51,x52,x53,
-   x61,x62,x63;
+ T m_x11,m_x12,m_x13,
+   m_x21,m_x22,m_x23,
+   m_x31,m_x32,m_x33,
+   m_x41,m_x42,m_x43,
+   m_x51,m_x52,m_x53,
+   m_x61,m_x62,m_x63;
  bool applyTransform;
 
- template<class T>
- P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static
- T r2() {std::sqrt(T(2.0));}
+ static const T r2 = square_root(T(2.0));
 
- template<class T>
- P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static
- T r2i() {T(1.0)/std::sqrt(T(2.0));}
+ static const T r2i = T(1.0)/square_root(T(2.0));
 
- template<class T>
- P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static 
- T two() {T(2.0);}
+ static const T two = T(2.0);
 
  public:
   /**** constructors, destructors, and assigns ****/
@@ -66,19 +60,19 @@ class Mandel6x3
       T const& X41, T const& X42, T const& X43,
       T const& X51, T const& X52, T const& X53,
       T const& X61, T const& X62, T const& X63):
-      x11(X11),x12(X12),x13(X13),
-      x21(X21),x22(X22),x23(X23),
-      x31(X31),x32(X32),x33(X33),
-      x41(X41),x42(X42),x43(X43),
-      x51(X51),x52(X52),x53(X53),
-      x61(X61),x62(X62),x63(X63),
+      m_x11(X11),m_x12(X12),m_x13(X13),
+      m_x21(X21),m_x22(X22),m_x23(X23),
+      m_x31(X31),m_x32(X32),m_x33(X33),
+      m_x41(X41),m_x42(X42),m_x43(X43),
+      m_x51(X51),m_x52(X52),m_x53(X53),
+      m_x61(X61),m_x62(X62),m_x63(X63),
        applyTransform(true)
   {
     this->MandelXform();
   }
 
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  mandel6x6(
+  mandel6x3(
       T const& X11, T const& X12, T const& X13,
       T const& X21, T const& X22, T const& X23,
       T const& X31, T const& X32, T const& X33,
@@ -86,26 +80,27 @@ class Mandel6x3
       T const& X51, T const& X52, T const& X53,
       T const& X61, T const& X62, T const& X63, 
       bool const& Xform):
-    x11(X11),x12(X12),x13(X13),
-    x21(X21),x22(X22),x23(X23),
-    x31(X31),x32(X32),x33(X33),
-    x41(X41),x42(X42),x43(X43),
-    x51(X51),x52(X52),x53(X53),
-    x61(X61),x62(X62),x63(X63),
+    m_x11(X11),m_x12(X12),m_x13(X13),
+    m_x21(X21),m_x22(X22),m_x23(X23),
+    m_x31(X31),m_x32(X32),m_x33(X33),
+    m_x41(X41),m_x42(X42),m_x43(X43),
+    m_x51(X51),m_x52(X52),m_x53(X53),
+    m_x61(X61),m_x62(X62),m_x63(X63),
     applyTransform(Xform)
   {
     if (applyTransform)
         this->MandelXform();
   }
+
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   mandel6x3(
       static_matrix<T,6,3> const& X, bool const& Xform):
-    x11(X(0,0)),x12(X(0,1)),x13(X(0,2)),
-    x21(X(1,0)),x22(X(1,1)),x23(X(1,2)),
-    x31(X(2,0)),x32(X(2,1)),x33(X(2,2)),
-    x41(X(3,0)),x42(X(3,1)),x43(X(3,2)),
-    x51(X(4,0)),x52(X(4,1)),x53(X(4,2)),
-    x61(X(5,0)),x62(X(5,1)),x63(X(5,2)),
+    m_x11(X(0,0)),m_x12(X(0,1)),m_x13(X(0,2)),
+    m_x21(X(1,0)),m_x22(X(1,1)),m_x23(X(1,2)),
+    m_x31(X(2,0)),m_x32(X(2,1)),m_x33(X(2,2)),
+    m_x41(X(3,0)),m_x42(X(3,1)),m_x43(X(3,2)),
+    m_x51(X(4,0)),m_x52(X(4,1)),m_x53(X(4,2)),
+    m_x61(X(5,0)),m_x62(X(5,1)),m_x63(X(5,2)),
     applyTransform(Xform)
   {
     if (applyTransform)
@@ -115,12 +110,12 @@ class Mandel6x3
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   mandel6x3(
       static_matrix<T,6,3> const& X):
-    x11(X(0,0)),x12(X(0,1)),x13(X(0,2)),
-    x21(X(1,0)),x22(X(1,1)),x23(X(1,2)),
-    x31(X(2,0)),x32(X(2,1)),x33(X(2,2)),
-    x41(X(3,0)),x42(X(3,1)),x43(X(3,2)),
-    x51(X(4,0)),x52(X(4,1)),x53(X(4,2)),
-    x61(X(5,0)),x62(X(5,1)),x63(X(5,2)),
+    m_x11(X(0,0)),m_x12(X(0,1)),m_x13(X(0,2)),
+    m_x21(X(1,0)),m_x22(X(1,1)),m_x23(X(1,2)),
+    m_x31(X(2,0)),m_x32(X(2,1)),m_x33(X(2,2)),
+    m_x41(X(3,0)),m_x42(X(3,1)),m_x43(X(3,2)),
+    m_x51(X(4,0)),m_x52(X(4,1)),m_x53(X(4,2)),
+    m_x61(X(5,0)),m_x62(X(5,1)),m_x63(X(5,2)),
     applyTransform(true)
   {
     this->MandelXform();
@@ -128,80 +123,80 @@ class Mandel6x3
 
   //return by mandel index 1-6
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x11() const { return x11; }
+  T const& x11() const { return m_x11; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x12() const { return x12; }
+  T const& x12() const { return m_x12; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x13() const { return x13; }
+  T const& x13() const { return m_x13; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x21() const { return x21; }
+  T const& x21() const { return m_x21; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x22() const { return x22; }
+  T const& x22() const { return m_x22; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x23() const { return x23; }
+  T const& x23() const { return m_x23; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x31() const { return x31; }
+  T const& x31() const { return m_x31; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x32() const { return x32; }
+  T const& x32() const { return m_x32; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x33() const { return x33; }
+  T const& x33() const { return m_x33; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x41() const { return x41; }
+  T const& x41() const { return m_x41; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x42() const { return x42; }
+  T const& x42() const { return m_x42; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x43() const { return x43; }
+  T const& x43() const { return m_x43; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x51() const { return x51; }
+  T const& x51() const { return m_x51; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x52() const { return x52; }
+  T const& x52() const { return m_x52; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x53() const { return x53; }
+  T const& x53() const { return m_x53; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x61() const { return x61; }
+  T const& x61() const { return m_x61; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x62() const { return x62; }
+  T const& x62() const { return m_x62; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x63() const { return x63; }
+  T const& x63() const { return m_x63; }
 
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x11() { return x11; }
+  T& x11() { return m_x11; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x12() { return x12; }
+  T& x12() { return m_x12; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x13() { return x13; }
+  T& x13() { return m_x13; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x21() { return x21; }
+  T& x21() { return m_x21; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x22() { return x22; }
+  T& x22() { return m_x22; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x23() { return x23; }
+  T& x23() { return m_x23; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x31() { return x31; }
+  T& x31() { return m_x31; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x32() { return x32; }
+  T& x32() { return m_x32; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x33() { return x33; }
+  T& x33() { return m_x33; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x41() { return x41; }
+  T& x41() { return m_x41; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x42() { return x42; }
+  T& x42() { return m_x42; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x43() { return x43; }
+  T& x43() { return m_x43; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x51() { return x51; }
+  T& x51() { return m_x51; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x52() { return x52; }
+  T& x52() { return m_x52; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x53() { return x53; }
+  T& x53() { return m_x53; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x61() { return x61; }
+  T& x61() { return m_x61; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x62() { return x62; }
+  T& x62() { return m_x62; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x63() { return x63; }
+  T& x63() { return m_x63; }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
   mandel6x3<T> zero()
   {
     return mandel6x3<T>(
@@ -214,7 +209,7 @@ class Mandel6x3
         false);
   }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
   mandel6x3<T> identity()
   {
     return mandel6x3<T>(
@@ -227,20 +222,20 @@ class Mandel6x3
         true);
   }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   void MandelXform()
   {
-       x41*=r2i, x42*=r2i, x43*=r2i,
-       x51*=r2i, x52*=r2i, x53*=r2i,
-       x61*=r2i, x62*=r2i, x63*=r2i;
+       m_x41*=r2i, m_x42*=r2i, m_x43*=r2i,
+       m_x51*=r2i, m_x52*=r2i, m_x53*=r2i,
+       m_x61*=r2i, m_x62*=r2i, m_x63*=r2i;
   }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   void invMandelXform()
   {
-       x41/=r2i, x42/=r2i, x43/=r2i,
-       x51/=r2i, x52/=r2i, x53/=r2i,
-       x61/=r2i, x62/=r2i, x63/=r2i;
+       m_x41/=r2i, m_x42/=r2i, m_x43/=r2i,
+       m_x51/=r2i, m_x52/=r2i, m_x53/=r2i,
+       m_x61/=r2i, m_x62/=r2i, m_x63/=r2i;
   }
 
 };
@@ -257,7 +252,7 @@ operator*(
         mandel6x3<A> const& a, 
         B const& c)
 {
-    return mandel6x3<decltype(a.x11()*c)>(
+    return mandel6x3<decltype(A()*B())>(
             a.x11()*c, a.x12()*c, a.x13()*c,
             a.x21()*c, a.x22()*c, a.x23()*c,
             a.x31()*c, a.x32()*c, a.x33()*c,
@@ -286,7 +281,7 @@ operator/(
         mandel6x3<A> const& a, 
         B const& c)
 {
-    return mandel6x3<decltype<(a.x11() / c)>(
+    return mandel6x3<decltype(A()*B())>(
             a.x11()/c, a.x12()/c, a.x13()/c,
             a.x21()/c, a.x22()/c, a.x23()/c,
             a.x31()/c, a.x32()/c, a.x33()/c,
@@ -298,7 +293,7 @@ operator/(
 
 //division /= by constant
 template <class A>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator/=(
         mandel6x3<A>& a, 
         A const& c)
@@ -325,7 +320,7 @@ void operator/=(
 
 //multiplication *= by constant
 template <class A>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator*=(
         mandel6x3<A>& a, 
         A const& c)
@@ -352,7 +347,7 @@ void operator*=(
 
 //mandel6x6 += addition
 template <class T>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator+=(
     mandel6x6<T>& a, 
     mandel6x6<T> const& b)
@@ -379,7 +374,7 @@ void operator+=(
 
 //mandel6x3 -= subtraction
 template <class T>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator-=(
     mandel6x3<T>& a, 
     mandel6x3<T> const& b)

--- a/p3a_mandel6x3.hpp
+++ b/p3a_mandel6x3.hpp
@@ -665,4 +665,20 @@ auto operator*(
 //misc
 inline int constexpr mandel6x3_component_count = 18;
 
+//output print
+template <class U>
+P3A_ALWAYS_INLINE constexpr 
+std::ostream& operator<<(std::ostream& os, mandel6x3<U> const& a)
+{
+
+    os << std::cout.precision(4);
+    os << std::scientific;
+    std::cout << "\t  | " << a.x1()       << " " << a.x6()*a.r2i << " " << a.x5()*a.r2i << " |" <<std::endl;
+    std::cout << "\t  | " << a.x6()*a.r2i << " " << a.x2()       << " " << a.x4()*a.r2i << " |" <<std::endl;
+    std::cout << "\t  | " << a.x5()*a.r2i << " " << a.x4()*a.r2i << " " << a.x3()       << " |" <<std::endl;
+
+    return os;
+
+}
+
 }

--- a/p3a_mandel6x3.hpp
+++ b/p3a_mandel6x3.hpp
@@ -13,6 +13,12 @@
  *
  * - `mandel6x3` (6x3) 3rd order Tensor
  *
+ *   Constructors:
+ *   
+ *   - `mandel6x3(mandel6x3)`
+ *   - `mandel6x3(<list of values>)`
+ *   - `mandel6x3(static_matrix<6,3>)` -- includes testing for symmetry
+ *
  * See additional notes in `p3a_mandel6x1.hpp`.
  */
 
@@ -35,9 +41,17 @@ class Mandel6x3
    x61,x62,x63;
  bool applyTransform;
 
- const T r2 = std::sqrt(T(2.0));
- const T r2i = T(1.0)/std::sqrt(T(2.0));
- const T two = T(2.0);
+ template<class T>
+ P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static
+ T r2() {std::sqrt(T(2.0));}
+
+ template<class T>
+ P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static
+ T r2i() {T(1.0)/std::sqrt(T(2.0));}
+
+ template<class T>
+ P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static 
+ T two() {T(2.0);}
 
  public:
   /**** constructors, destructors, and assigns ****/
@@ -82,6 +96,34 @@ class Mandel6x3
   {
     if (applyTransform)
         this->MandelXform();
+  }
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x3(
+      static_matrix<T,6,3> const& X, bool const& Xform):
+    x11(X(0,0)),x12(X(0,1)),x13(X(0,2)),
+    x21(X(1,0)),x22(X(1,1)),x23(X(1,2)),
+    x31(X(2,0)),x32(X(2,1)),x33(X(2,2)),
+    x41(X(3,0)),x42(X(3,1)),x43(X(3,2)),
+    x51(X(4,0)),x52(X(4,1)),x53(X(4,2)),
+    x61(X(5,0)),x62(X(5,1)),x63(X(5,2)),
+    applyTransform(Xform)
+  {
+    if (applyTransform)
+        this->MandelXform();
+  }
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x3(
+      static_matrix<T,6,3> const& X):
+    x11(X(0,0)),x12(X(0,1)),x13(X(0,2)),
+    x21(X(1,0)),x22(X(1,1)),x23(X(1,2)),
+    x31(X(2,0)),x32(X(2,1)),x33(X(2,2)),
+    x41(X(3,0)),x42(X(3,1)),x43(X(3,2)),
+    x51(X(4,0)),x52(X(4,1)),x53(X(4,2)),
+    x61(X(5,0)),x62(X(5,1)),x63(X(5,2)),
+    applyTransform(true)
+  {
+    this->MandelXform();
   }
 
   //return by mandel index 1-6

--- a/p3a_mandel6x3.hpp
+++ b/p3a_mandel6x3.hpp
@@ -1,0 +1,566 @@
+#pragma once
+
+#include "p3a_macros.hpp"
+#include "p3a_diagonal3x3.hpp"
+#include "p3a_vector3.hpp"
+#include "p3a_symmetric3x3.hpp"
+#include "p3a_matrix3x3.hpp"
+#include "p3a_mandel6x1.hpp"
+#include "p3a_mandel6x6.hpp"
+#include "p3a_mandel3x6.hpp"
+/********************************* NOTES ************************************
+ * This header provides the class: 
+ *
+ * - `mandel6x3` (6x3) 3rd order Tensor
+ *
+ * See additional notes in `p3a_mandel6x1.hpp`.
+ */
+
+namespace p3a {
+
+/******************************************************************/
+/******************************************************************/
+template <class T>
+class Mandel6x3
+/** 
+ * Represents a 3th order tensor as a 6x3 Mandel array
+ */
+/******************************************************************/
+{
+ T x11,x12,x13,
+   x21,x22,x23,
+   x31,x32,x33,
+   x41,x42,x43,
+   x51,x52,x53,
+   x61,x62,x63;
+ bool applyTransform;
+
+ const T r2 = std::sqrt(T(2.0));
+ const T r2i = T(1.0)/std::sqrt(T(2.0));
+ const T two = T(2.0);
+
+ public:
+  /**** constructors, destructors, and assigns ****/
+  P3A_ALWAYS_INLINE constexpr
+  mandel6x3() = default;
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x6(
+      T const& X11, T const& X12, T const& X13,
+      T const& X21, T const& X22, T const& X23,
+      T const& X31, T const& X32, T const& X33,
+      T const& X41, T const& X42, T const& X43,
+      T const& X51, T const& X52, T const& X53,
+      T const& X61, T const& X62, T const& X63):
+      x11(X11),x12(X12),x13(X13),
+      x21(X21),x22(X22),x23(X23),
+      x31(X31),x32(X32),x33(X33),
+      x41(X41),x42(X42),x43(X43),
+      x51(X51),x52(X52),x53(X53),
+      x61(X61),x62(X62),x63(X63),
+       applyTransform(true)
+  {
+    this->MandelXform();
+  }
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x6(
+      T const& X11, T const& X12, T const& X13,
+      T const& X21, T const& X22, T const& X23,
+      T const& X31, T const& X32, T const& X33,
+      T const& X41, T const& X42, T const& X43,
+      T const& X51, T const& X52, T const& X53,
+      T const& X61, T const& X62, T const& X63, 
+      bool const& Xform):
+    x11(X11),x12(X12),x13(X13),
+    x21(X21),x22(X22),x23(X23),
+    x31(X31),x32(X32),x33(X33),
+    x41(X41),x42(X42),x43(X43),
+    x51(X51),x52(X52),x53(X53),
+    x61(X61),x62(X62),x63(X63),
+    applyTransform(Xform)
+  {
+    if (applyTransform)
+        this->MandelXform();
+  }
+
+  //return by mandel index 1-6
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x11() const { return x11; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x12() const { return x12; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x13() const { return x13; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x21() const { return x21; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x22() const { return x22; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x23() const { return x23; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x31() const { return x31; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x32() const { return x32; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x33() const { return x33; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x41() const { return x41; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x42() const { return x42; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x43() const { return x43; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x51() const { return x51; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x52() const { return x52; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x53() const { return x53; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x61() const { return x61; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x62() const { return x62; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x63() const { return x63; }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x11() { return x11; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x12() { return x12; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x13() { return x13; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x21() { return x21; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x22() { return x22; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x23() { return x23; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x31() { return x31; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x32() { return x32; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x33() { return x33; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x41() { return x41; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x42() { return x42; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x43() { return x43; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x51() { return x51; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x52() { return x52; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x53() { return x53; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x61() { return x61; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x62() { return x62; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x63() { return x63; }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  mandel6x3<T> zero()
+  {
+    return mandel6x3<T>(
+        T(0), T(0), T(0),
+        T(0), T(0), T(0),
+        T(0), T(0), T(0),
+        T(0), T(0), T(0),
+        T(0), T(0), T(0),
+        T(0), T(0), T(0),
+        false);
+  }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  mandel6x3<T> identity()
+  {
+    return mandel6x3<T>(
+        T(1), T(0), T(0),
+        T(0), T(1), T(0),
+        T(0), T(0), T(1),
+        T(0), T(0), T(0),
+        T(0), T(0), T(0),
+        T(0), T(0), T(0),
+        true);
+  }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  void MandelXform()
+  {
+       x41*=r2i, x42*=r2i, x43*=r2i,
+       x51*=r2i, x52*=r2i, x53*=r2i,
+       x61*=r2i, x62*=r2i, x63*=r2i;
+  }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  void invMandelXform()
+  {
+       x41/=r2i, x42/=r2i, x43/=r2i,
+       x51/=r2i, x52/=r2i, x53/=r2i,
+       x61/=r2i, x62/=r2i, x63/=r2i;
+  }
+
+};
+
+/***************************************************************************** 
+ * Operator overloads for mandel6x3 tensors (3rd order tensor)
+ *****************************************************************************/
+//mandel6x3 binary operators with scalars
+//multiplication by constant
+template <class A, class B>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+typename std::enable_if<is_scalar<B>, mandel6x6<decltype(A() * B())>>::type
+operator*(
+        mandel6x3<A> const& a, 
+        B const& c)
+{
+    return mandel6x3<decltype(a.x11()*c)>(
+            a.x11()*c, a.x12()*c, a.x13()*c,
+            a.x21()*c, a.x22()*c, a.x23()*c,
+            a.x31()*c, a.x32()*c, a.x33()*c,
+            a.x41()*c, a.x42()*c, a.x43()*c,
+            a.x51()*c, a.x52()*c, a.x53()*c,
+            a.x61()*c, a.x62()*c, a.x63()*c,
+            false);
+}
+
+//multiplication by constant
+template <class A, class B>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+typename std::enable_if<is_scalar<A>, mandel6x6<decltype(A() * B())>>::type 
+operator*(
+        A const& c, 
+        mandel6x3<B> const& t)
+{
+    return t * c;
+}
+
+//division by constant
+template <class A, class B>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+typename std::enable_if<is_scalar<B>, mandel6x6<decltype(A() * B())>>::type
+operator/(
+        mandel6x3<A> const& a, 
+        B const& c)
+{
+    return mandel6x3<decltype<(a.x11() / c)>(
+            a.x11()/c, a.x12()/c, a.x13()/c,
+            a.x21()/c, a.x22()/c, a.x23()/c,
+            a.x31()/c, a.x32()/c, a.x33()/c,
+            a.x41()/c, a.x42()/c, a.x43()/c,
+            a.x51()/c, a.x52()/c, a.x53()/c,
+            a.x61()/c, a.x62()/c, a.x63()/c,
+            false);
+}
+
+//division /= by constant
+template <class A>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator/=(
+        mandel6x3<A>& a, 
+        A const& c)
+{
+        a.x11()/=c; 
+        a.x12()/=c; 
+        a.x13()/=c; 
+        a.x21()/=c;
+        a.x22()/=c;
+        a.x23()/=c;
+        a.x31()/=c;
+        a.x32()/=c;
+        a.x33()/=c;
+        a.x41()/=c;
+        a.x42()/=c;
+        a.x43()/=c;
+        a.x51()/=c;
+        a.x52()/=c;
+        a.x53()/=c;
+        a.x61()/=c;
+        a.x62()/=c;
+        a.x63()/=c;
+}
+
+//multiplication *= by constant
+template <class A>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator*=(
+        mandel6x3<A>& a, 
+        A const& c)
+{
+        a.x11()*=c; 
+        a.x12()*=c; 
+        a.x13()*=c; 
+        a.x21()*=c;
+        a.x22()*=c;
+        a.x23()*=c;
+        a.x31()*=c;
+        a.x32()*=c;
+        a.x33()*=c;
+        a.x41()*=c;
+        a.x42()*=c;
+        a.x43()*=c;
+        a.x51()*=c;
+        a.x52()*=c;
+        a.x53()*=c;
+        a.x61()*=c;
+        a.x62()*=c;
+        a.x63()*=c;
+}
+
+//mandel6x6 += addition
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator+=(
+    mandel6x6<T>& a, 
+    mandel6x6<T> const& b)
+{
+    a.x11() += b.x11();
+    a.x12() += b.x12();
+    a.x13() += b.x13();
+    a.x21() += b.x21();
+    a.x22() += b.x22();
+    a.x23() += b.x23(); 
+    a.x31() += b.x31();
+    a.x32() += b.x32();
+    a.x33() += b.x33(); 
+    a.x41() += b.x41();
+    a.x42() += b.x42();
+    a.x43() += b.x43();
+    a.x51() += b.x51();
+    a.x52() += b.x52();
+    a.x53() += b.x53();
+    a.x61() += b.x61(); 
+    a.x62() += b.x62();
+    a.x63() += b.x63();
+}
+
+//mandel6x3 -= subtraction
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator-=(
+    mandel6x3<T>& a, 
+    mandel6x3<T> const& b)
+{
+    a.x11() -= b.x11();
+    a.x12() -= b.x12();
+    a.x13() -= b.x13();
+    a.x21() -= b.x21();
+    a.x22() -= b.x22();
+    a.x23() -= b.x23(); 
+    a.x31() -= b.x31();
+    a.x32() -= b.x32();
+    a.x33() -= b.x33(); 
+    a.x41() -= b.x41();
+    a.x42() -= b.x42();
+    a.x43() -= b.x43();
+    a.x51() -= b.x51();
+    a.x52() -= b.x52();
+    a.x53() -= b.x53();
+    a.x61() -= b.x61(); 
+    a.x62() -= b.x62();
+    a.x63() -= b.x63();
+}
+
+//mandel6x3 addition
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator+(
+    mandel6x3<T> const& a, 
+    mandel6x3<U> const& b)
+{
+  return mandel6x3<decltype(a.x11()+b.x11())>(
+    a.x11() + b.x11(), a.x12() + b.x12(), a.x13() + b.x13(),
+    a.x21() + b.x21(), a.x22() + b.x22(), a.x23() + b.x23(),
+    a.x31() + b.x31(), a.x32() + b.x32(), a.x33() + b.x33(),
+    a.x41() + b.x41(), a.x42() + b.x42(), a.x43() + b.x43(),
+    a.x51() + b.x51(), a.x52() + b.x52(), a.x53() + b.x53(),
+    a.x61() + b.x61(), a.x62() + b.x62(), a.x63() + b.x63(),
+    false);
+}
+
+//mandel6x3 subtraction
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator-(
+    mandel6x3<T> const& a, 
+    mandel6x3<U> const& b)
+{
+  return mandel6x3<decltype(a.x11()-b.x11())>(
+    a.x11() - b.x11(), a.x12() - b.x12(), a.x13() - b.x13(), 
+    a.x21() - b.x21(), a.x22() - b.x22(), a.x23() - b.x23(),
+    a.x31() - b.x31(), a.x32() - b.x32(), a.x33() - b.x33(),
+    a.x41() - b.x41(), a.x42() - b.x42(), a.x43() - b.x43(),
+    a.x51() - b.x51(), a.x52() - b.x52(), a.x53() - b.x53(),
+    a.x61() - b.x61(), a.x62() - b.x62(), a.x63() - b.x63(),
+    false);
+}
+
+//mandel6x3 negation
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+mandel6x3<T> operator-(
+    mandel6x3<T> const& a)
+{
+  return mandel6x3<T>(
+    -a.x11(), -a.x12(), -a.x13(),
+    -a.x21(), -a.x22(), -a.x23(),
+    -a.x31(), -a.x32(), -a.x33(),
+    -a.x41(), -a.x42(), -a.x43(),
+    -a.x51(), -a.x52(), -a.x53(),
+    -a.x61(), -a.x62(), -a.x63(),
+    false);
+}
+
+/***************************************************************************** 
+ * Linear Algebra for mandel6x3 (3rd order tensor)
+ *****************************************************************************/
+//trace
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+T trace(
+    mandel6x3<T> const& a)
+{
+  return a.x11() + a.x22() + a.x33();
+}
+
+/** transpose 6x3 to 3x6 **/
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+mandel3x6<T> transpose(
+    mandel6x3<T> const &d)
+{
+    return mandel3x6<T>(
+        d.x11(), d.x21(), d.x31(), d.x41(), d.x51(), d.x61(),
+        d.x12(), d.x22(), d.x32(), d.x42(), d.x52(), d.x62(),
+        d.x13(), d.x23(), d.x33(), d.x43(), d.x53(), d.x63(),
+        false); //already transformed
+}
+
+/** transpose 3x6 to 6x3 **/
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+mandel6x3<T> transpose(
+    mandel3x6<T> const &d)
+{
+    return mandel6x3<T>(
+        d.x11(), d.x21(), d.x31(),
+        d.x12(), d.x22(), d.x32(),
+        d.x13(), d.x23(), d.x33(),
+        d.x14(), d.x24(), d.x34(),
+        d.x15(), d.x25(), d.x35(),
+        d.x16(), d.x26(), d.x36(),
+        false); //already transformed
+}
+
+/** Tensor multiply mandel3x6 (3x6) by mandel6x3 (6x3) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel3x6<T> const &e,
+    mandel6x3<U> const &d)
+{
+    return matrix3x3<decltype(e.x11*d.x11)>(
+            e.x11()*d.x11() + e.x12()*d.x21() + e.x13()*d.x31() + e.x14()*d.x41() + e.x15()*d.x51() + e.x16()*d.x61(),
+            e.x11()*d.x12() + e.x12()*d.x22() + e.x13()*d.x32() + e.x14()*d.x42() + e.x15()*d.x52() + e.x16()*d.x62(),
+            e.x11()*d.x13() + e.x12()*d.x23() + e.x13()*d.x33() + e.x14()*d.x43() + e.x15()*d.x53() + e.x16()*d.x63(),
+            e.x21()*d.x11() + e.x22()*d.x21() + e.x23()*d.x31() + e.x24()*d.x41() + e.x25()*d.x51() + e.x26()*d.x61(),
+            e.x21()*d.x12() + e.x22()*d.x22() + e.x23()*d.x32() + e.x24()*d.x42() + e.x25()*d.x52() + e.x26()*d.x62(),
+            e.x21()*d.x13() + e.x22()*d.x23() + e.x23()*d.x33() + e.x24()*d.x43() + e.x25()*d.x53() + e.x26()*d.x63(),
+            e.x31()*d.x11() + e.x32()*d.x21() + e.x33()*d.x31() + e.x34()*d.x41() + e.x35()*d.x51() + e.x36()*d.x61(),
+            e.x31()*d.x12() + e.x32()*d.x22() + e.x33()*d.x32() + e.x34()*d.x42() + e.x35()*d.x52() + e.x36()*d.x62(),
+            e.x31()*d.x13() + e.x32()*d.x23() + e.x33()*d.x33() + e.x34()*d.x43() + e.x35()*d.x53() + e.x36()*d.x63());
+}
+
+/** Tensor multiply Mandel6x3 (6x3) by matrix3x3 (3x3) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x3<T> const &e, 
+    matrix3x3<U> const &d)
+{
+    return mandel6x3<decltype(e.x11()*d.xx())>(
+            e.x11()*d.xx() + e.x12()*d.yx() + e.x13()*d.zx(), e.x11()*d.xy() + e.x12()*d.yy() + e.x13()*d.zy(), e.x11()*d.xz() + e.x12()*d.yz() + e.x13()*d.zz(),
+            e.x21()*d.xx() + e.x22()*d.yx() + e.x23()*d.zx(), e.x21()*d.xy() + e.x22()*d.yy() + e.x23()*d.zy(), e.x21()*d.xz() + e.x22()*d.yz() + e.x23()*d.zz(),
+            e.x31()*d.xx() + e.x32()*d.yx() + e.x33()*d.zx(), e.x31()*d.xy() + e.x32()*d.yy() + e.x33()*d.zy(), e.x31()*d.xz() + e.x32()*d.yz() + e.x33()*d.zz(),
+            e.x41()*d.xx() + e.x42()*d.yx() + e.x43()*d.zx(), e.x41()*d.xy() + e.x42()*d.yy() + e.x43()*d.zy(), e.x41()*d.xz() + e.x42()*d.yz() + e.x43()*d.zz(),
+            e.x51()*d.xx() + e.x52()*d.yx() + e.x53()*d.zx(), e.x51()*d.xy() + e.x52()*d.yy() + e.x53()*d.zy(), e.x51()*d.xz() + e.x52()*d.yz() + e.x53()*d.zz(),
+            e.x61()*d.xx() + e.x62()*d.yx() + e.x63()*d.zx(), e.x61()*d.xy() + e.x62()*d.yy() + e.x63()*d.zy(), e.x61()*d.xz() + e.x62()*d.yz() + e.x63()*d.zz(),
+            false);//already transformed
+}
+
+/** Tensor Dot mandel6x3 (6x3) by mandel6x1 (6x1) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x3<T> const &e, 
+    mandel6x1<U> const &f)
+{
+    using result_type decltype(e.x11(),f.x11()) 
+    matrix3x3<result_type> d = f;
+    return mandel6x3<result_type>(
+            e.x11()*d.xx() + e.x12()*d.yx() + e.x13()*d.zx(), e.x11()*d.xy() + e.x12()*d.yy() + e.x13()*d.zy(), e.x11()*d.xz() + e.x12()*d.yz() + e.x13()*d.zz(),
+            e.x21()*d.xx() + e.x22()*d.yx() + e.x23()*d.zx(), e.x21()*d.xy() + e.x22()*d.yy() + e.x23()*d.zy(), e.x21()*d.xz() + e.x22()*d.yz() + e.x23()*d.zz(),
+            e.x31()*d.xx() + e.x32()*d.yx() + e.x33()*d.zx(), e.x31()*d.xy() + e.x32()*d.yy() + e.x33()*d.zy(), e.x31()*d.xz() + e.x32()*d.yz() + e.x33()*d.zz(),
+            e.x41()*d.xx() + e.x42()*d.yx() + e.x43()*d.zx(), e.x41()*d.xy() + e.x42()*d.yy() + e.x43()*d.zy(), e.x41()*d.xz() + e.x42()*d.yz() + e.x43()*d.zz(),
+            e.x51()*d.xx() + e.x52()*d.yx() + e.x53()*d.zx(), e.x51()*d.xy() + e.x52()*d.yy() + e.x53()*d.zy(), e.x51()*d.xz() + e.x52()*d.yz() + e.x53()*d.zz(),
+            e.x61()*d.xx() + e.x62()*d.yx() + e.x63()*d.zx(), e.x61()*d.xy() + e.x62()*d.yy() + e.x63()*d.zy(), e.x61()*d.xz() + e.x62()*d.yz() + e.x63()*d.zz(),
+            false);//already transformed
+}
+
+/** Tensor Dot mandel6x3 (6x3) by symmetric3x3 (3x3) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x3<T> const &e, 
+    symmetric3x3<U> const &f)
+{
+    using result_type decltype(e.x11(),f.x11()) 
+    matrix3x3<result_type> d = f;
+    return mandel6x3<result_type>(
+            e.x11()*d.xx() + e.x12()*d.yx() + e.x13()*d.zx(), e.x11()*d.xy() + e.x12()*d.yy() + e.x13()*d.zy(), e.x11()*d.xz() + e.x12()*d.yz() + e.x13()*d.zz(),
+            e.x21()*d.xx() + e.x22()*d.yx() + e.x23()*d.zx(), e.x21()*d.xy() + e.x22()*d.yy() + e.x23()*d.zy(), e.x21()*d.xz() + e.x22()*d.yz() + e.x23()*d.zz(),
+            e.x31()*d.xx() + e.x32()*d.yx() + e.x33()*d.zx(), e.x31()*d.xy() + e.x32()*d.yy() + e.x33()*d.zy(), e.x31()*d.xz() + e.x32()*d.yz() + e.x33()*d.zz(),
+            e.x41()*d.xx() + e.x42()*d.yx() + e.x43()*d.zx(), e.x41()*d.xy() + e.x42()*d.yy() + e.x43()*d.zy(), e.x41()*d.xz() + e.x42()*d.yz() + e.x43()*d.zz(),
+            e.x51()*d.xx() + e.x52()*d.yx() + e.x53()*d.zx(), e.x51()*d.xy() + e.x52()*d.yy() + e.x53()*d.zy(), e.x51()*d.xz() + e.x52()*d.yz() + e.x53()*d.zz(),
+            e.x61()*d.xx() + e.x62()*d.yx() + e.x63()*d.zx(), e.x61()*d.xy() + e.x62()*d.yy() + e.x63()*d.zy(), e.x61()*d.xz() + e.x62()*d.yz() + e.x63()*d.zz(),
+            false);//already transformed
+}
+
+/** Tensor multiply MandelVector (6x3) by diagonal3x3 (3x3) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x6<T> const &v, 
+    diagonal3x3<U> const &d)
+{
+    return mandel6x3<decltype(e.x11(),d.xx())>(
+            e.x11()*d.xx(), e.x12()*d.yy(), e.x13()*d.zz(),
+            e.x21()*d.xx(), e.x22()*d.yy(), e.x23()*d.zz(),
+            e.x31()*d.xx(), e.x32()*d.yy(), e.x33()*d.zz(),
+            e.x41()*d.xx(), e.x42()*d.yy(), e.x43()*d.zz(),
+            e.x51()*d.xx(), e.x52()*d.yy(), e.x53()*d.zz(),
+            e.x61()*d.xx(), e.x62()*d.yy(), e.x63()*d.zz(),
+            false);//already transformed
+}
+
+/** Tensor multiply MandelVector (6x3) by vector3 (3x1) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x3<T> const &C, 
+    vector3<U> const &v)
+{
+    return mandel6x1<decltype(C.x11()*v.x())>(
+            C.x11()*v.x() + C.x12()*v.y() + C.x13()*v.z(),
+            C.x21()*v.x() + C.x22()*v.y() + C.x23()*v.z(),
+            C.x31()*v.x() + C.x32()*v.y() + C.x33()*v.z(),
+            C.x41()*v.x() + C.x42()*v.y() + C.x43()*v.z(),
+            C.x51()*v.x() + C.x52()*v.y() + C.x53()*v.z(),
+            C.x61()*v.x() + C.x62()*v.y() + C.x63()*v.z(),
+            false);//already transformed
+}
+
+//misc
+inline int constexpr mandel6x3_component_count = 18;
+

--- a/p3a_mandel6x3.hpp
+++ b/p3a_mandel6x3.hpp
@@ -41,19 +41,19 @@ class mandel6x3
    m_x61,m_x62,m_x63;
  bool applyTransform;
 
- static const T r2 = square_root(T(2.0));
-
- static const T r2i = T(1.0)/square_root(T(2.0));
-
- static const T two = T(2.0);
-
  public:
+  static constexpr T r2 = std::sqrt(T(2.0));
+
+  static constexpr T r2i = T(1.0)/std::sqrt(T(2.0));
+
+  static constexpr T two = T(2.0);
+
   /**** constructors, destructors, and assigns ****/
   P3A_ALWAYS_INLINE constexpr
   mandel6x3() = default;
 
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  mandel6x6(
+  mandel6x3(
       T const& X11, T const& X12, T const& X13,
       T const& X21, T const& X22, T const& X23,
       T const& X31, T const& X32, T const& X33,
@@ -241,13 +241,12 @@ class mandel6x3
 };
 
 /***************************************************************************** 
- * Operator overloads for mandel6x3 tensors (3rd order tensor)
  *****************************************************************************/
 //mandel6x3 binary operators with scalars
 //multiplication by constant
 template <class A, class B>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-typename std::enable_if<is_scalar<B>, mandel6x6<decltype(A() * B())>>::type
+typename std::enable_if<is_scalar<B>, mandel6x3<decltype(A() * B())>>::type
 operator*(
         mandel6x3<A> const& a, 
         B const& c)
@@ -265,7 +264,7 @@ operator*(
 //multiplication by constant
 template <class A, class B>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-typename std::enable_if<is_scalar<A>, mandel6x6<decltype(A() * B())>>::type 
+typename std::enable_if<is_scalar<A>, mandel6x3<decltype(A() * B())>>::type 
 operator*(
         A const& c, 
         mandel6x3<B> const& t)
@@ -276,7 +275,7 @@ operator*(
 //division by constant
 template <class A, class B>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-typename std::enable_if<is_scalar<B>, mandel6x6<decltype(A() * B())>>::type
+typename std::enable_if<is_scalar<B>, mandel6x3<decltype(A() * B())>>::type
 operator/(
         mandel6x3<A> const& a, 
         B const& c)
@@ -345,12 +344,12 @@ void operator*=(
         a.x63()*=c;
 }
 
-//mandel6x6 += addition
+//mandel6x3 += addition
 template <class T>
 P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator+=(
-    mandel6x6<T>& a, 
-    mandel6x6<T> const& b)
+    mandel6x3<T>& a, 
+    mandel6x3<T> const& b)
 {
     a.x11() += b.x11();
     a.x12() += b.x12();
@@ -490,6 +489,53 @@ mandel6x3<T> transpose(
         false); //already transformed
 }
 
+/** Tensor multiply mandel6x3 (6x3) by mandel3x6 (3x6) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x3<T> const &e,
+    mandel3x6<U> const &d)
+{
+    return mandel6x6<decltype(e.x11()*d.x11())>(
+        e.x11()*d.x11() + e.x12()*d.x21() + e.x13()*d.x31(),
+        e.x11()*d.x12() + e.x12()*d.x22() + e.x13()*d.x32(),
+        e.x11()*d.x13() + e.x12()*d.x23() + e.x13()*d.x33(),
+        e.x11()*d.x14() + e.x12()*d.x24() + e.x13()*d.x34(),
+        e.x11()*d.x15() + e.x12()*d.x25() + e.x13()*d.x35(),
+        e.x11()*d.x16() + e.x12()*d.x26() + e.x13()*d.x36(),
+        e.x21()*d.x11() + e.x22()*d.x21() + e.x23()*d.x31(),
+        e.x21()*d.x12() + e.x22()*d.x22() + e.x23()*d.x32(),
+        e.x21()*d.x13() + e.x22()*d.x23() + e.x23()*d.x33(),
+        e.x21()*d.x14() + e.x22()*d.x24() + e.x23()*d.x34(),
+        e.x21()*d.x15() + e.x22()*d.x25() + e.x23()*d.x35(),
+        e.x21()*d.x16() + e.x22()*d.x26() + e.x23()*d.x36(),
+        e.x31()*d.x11() + e.x32()*d.x21() + e.x33()*d.x31(),
+        e.x31()*d.x12() + e.x32()*d.x22() + e.x33()*d.x32(),
+        e.x31()*d.x13() + e.x32()*d.x23() + e.x33()*d.x33(),
+        e.x31()*d.x14() + e.x32()*d.x24() + e.x33()*d.x34(),
+        e.x31()*d.x15() + e.x32()*d.x25() + e.x33()*d.x35(),
+        e.x31()*d.x16() + e.x32()*d.x26() + e.x33()*d.x36(),
+        e.x41()*d.x11() + e.x42()*d.x21() + e.x43()*d.x31(),
+        e.x41()*d.x12() + e.x42()*d.x22() + e.x43()*d.x32(),
+        e.x41()*d.x13() + e.x42()*d.x23() + e.x43()*d.x33(),
+        e.x41()*d.x14() + e.x42()*d.x24() + e.x43()*d.x34(),
+        e.x41()*d.x15() + e.x42()*d.x25() + e.x43()*d.x35(),
+        e.x41()*d.x16() + e.x42()*d.x26() + e.x43()*d.x36(),
+        e.x51()*d.x11() + e.x52()*d.x21() + e.x53()*d.x31(),
+        e.x51()*d.x12() + e.x52()*d.x22() + e.x53()*d.x32(),
+        e.x51()*d.x13() + e.x52()*d.x23() + e.x53()*d.x33(),
+        e.x51()*d.x14() + e.x52()*d.x24() + e.x53()*d.x34(),
+        e.x51()*d.x15() + e.x52()*d.x25() + e.x53()*d.x35(),
+        e.x51()*d.x16() + e.x52()*d.x26() + e.x53()*d.x36(),
+        e.x61()*d.x11() + e.x62()*d.x21() + e.x63()*d.x31(),
+        e.x61()*d.x12() + e.x62()*d.x22() + e.x63()*d.x32(),
+        e.x61()*d.x13() + e.x62()*d.x23() + e.x63()*d.x33(),
+        e.x61()*d.x14() + e.x62()*d.x24() + e.x63()*d.x34(),
+        e.x61()*d.x15() + e.x62()*d.x25() + e.x63()*d.x35(),
+        e.x61()*d.x16() + e.x62()*d.x26() + e.x63()*d.x36(),
+        false);//already transformed
+}
+
 /** Tensor multiply mandel3x6 (3x6) by mandel6x3 (6x3) **/
 template <class T, class U>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
@@ -497,7 +543,7 @@ auto operator*(
     mandel3x6<T> const &e,
     mandel6x3<U> const &d)
 {
-    return matrix3x3<decltype(e.x11*d.x11)>(
+    return matrix3x3<decltype(e.x11()*d.x11())>(
             e.x11()*d.x11() + e.x12()*d.x21() + e.x13()*d.x31() + e.x14()*d.x41() + e.x15()*d.x51() + e.x16()*d.x61(),
             e.x11()*d.x12() + e.x12()*d.x22() + e.x13()*d.x32() + e.x14()*d.x42() + e.x15()*d.x52() + e.x16()*d.x62(),
             e.x11()*d.x13() + e.x12()*d.x23() + e.x13()*d.x33() + e.x14()*d.x43() + e.x15()*d.x53() + e.x16()*d.x63(),
@@ -533,8 +579,8 @@ auto operator*(
     mandel6x3<T> const &e, 
     mandel6x1<U> const &f)
 {
-    using result_type decltype(e.x11(),f.x11()) 
-    matrix3x3<result_type> d = f;
+    using result_type = decltype(e.x11()*f.x1());
+    matrix3x3<result_type> d = mandel6x1_to_matrix3x3(f);
     return mandel6x3<result_type>(
             e.x11()*d.xx() + e.x12()*d.yx() + e.x13()*d.zx(), e.x11()*d.xy() + e.x12()*d.yy() + e.x13()*d.zy(), e.x11()*d.xz() + e.x12()*d.yz() + e.x13()*d.zz(),
             e.x21()*d.xx() + e.x22()*d.yx() + e.x23()*d.zx(), e.x21()*d.xy() + e.x22()*d.yy() + e.x23()*d.zy(), e.x21()*d.xz() + e.x22()*d.yz() + e.x23()*d.zz(),
@@ -552,8 +598,8 @@ auto operator*(
     mandel6x3<T> const &e, 
     symmetric3x3<U> const &f)
 {
-    using result_type decltype(e.x11(),f.x11()) 
-    matrix3x3<result_type> d = f;
+    using result_type = decltype(e.x11()*f.x11());
+    mandel6x1<result_type> d(f);
     return mandel6x3<result_type>(
             e.x11()*d.xx() + e.x12()*d.yx() + e.x13()*d.zx(), e.x11()*d.xy() + e.x12()*d.yy() + e.x13()*d.zy(), e.x11()*d.xz() + e.x12()*d.yz() + e.x13()*d.zz(),
             e.x21()*d.xx() + e.x22()*d.yx() + e.x23()*d.zx(), e.x21()*d.xy() + e.x22()*d.yy() + e.x23()*d.zy(), e.x21()*d.xz() + e.x22()*d.yz() + e.x23()*d.zz(),
@@ -568,7 +614,7 @@ auto operator*(
 template <class T, class U>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 auto operator*(
-    mandel6x6<T> const &v, 
+    mandel6x3<T> const &e, 
     diagonal3x3<U> const &d)
 {
     return mandel6x3<decltype(e.x11(),d.xx())>(
@@ -598,6 +644,25 @@ auto operator*(
             false);//already transformed
 }
 
+/** Tensor Dot mandel6x6 (6x6) by mandel6x3 (6x3)*/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x6<T> const &e, 
+    mandel6x3<U> const &d)
+{
+    return mandel6x3<decltype(e.x11()*d.x11())>(
+            e.x11()*d.x11() + e.x12()*d.x21() + e.x13()*d.x31() + e.x14()*d.x41() + e.x15()*d.x51() + e.x16()*d.x61(), e.x11()*d.x12() + e.x12()*d.x22() + e.x13()*d.x32() + e.x14()*d.x42() + e.x15()*d.x52() + e.x16()*d.x62(), e.x11()*d.x13() + e.x12()*d.x23() + e.x13()*d.x33() + e.x14()*d.x43() + e.x15()*d.x53() + e.x16()*d.x63(), 
+            e.x21()*d.x11() + e.x22()*d.x21() + e.x23()*d.x31() + e.x24()*d.x41() + e.x25()*d.x51() + e.x26()*d.x61(), e.x21()*d.x12() + e.x22()*d.x22() + e.x23()*d.x32() + e.x24()*d.x42() + e.x25()*d.x52() + e.x26()*d.x62(), e.x21()*d.x13() + e.x22()*d.x23() + e.x23()*d.x33() + e.x24()*d.x43() + e.x25()*d.x53() + e.x26()*d.x63(), 
+            e.x31()*d.x11() + e.x32()*d.x21() + e.x33()*d.x31() + e.x34()*d.x41() + e.x35()*d.x51() + e.x36()*d.x61(), e.x31()*d.x12() + e.x32()*d.x22() + e.x33()*d.x32() + e.x34()*d.x42() + e.x35()*d.x52() + e.x36()*d.x62(), e.x31()*d.x13() + e.x32()*d.x23() + e.x33()*d.x33() + e.x34()*d.x43() + e.x35()*d.x53() + e.x36()*d.x63(), 
+            e.x41()*d.x11() + e.x42()*d.x21() + e.x43()*d.x31() + e.x44()*d.x41() + e.x45()*d.x51() + e.x46()*d.x61(), e.x41()*d.x12() + e.x42()*d.x22() + e.x43()*d.x32() + e.x44()*d.x42() + e.x45()*d.x52() + e.x46()*d.x62(), e.x41()*d.x13() + e.x42()*d.x23() + e.x43()*d.x33() + e.x44()*d.x43() + e.x45()*d.x53() + e.x46()*d.x63(),
+            e.x51()*d.x11() + e.x52()*d.x21() + e.x53()*d.x31() + e.x54()*d.x41() + e.x55()*d.x51() + e.x56()*d.x61(), e.x51()*d.x12() + e.x52()*d.x22() + e.x53()*d.x32() + e.x54()*d.x42() + e.x55()*d.x52() + e.x56()*d.x62(), e.x51()*d.x13() + e.x52()*d.x23() + e.x53()*d.x33() + e.x54()*d.x43() + e.x55()*d.x53() + e.x56()*d.x63(), 
+            e.x61()*d.x11() + e.x62()*d.x21() + e.x63()*d.x31() + e.x64()*d.x41() + e.x65()*d.x51() + e.x66()*d.x61(), e.x61()*d.x12() + e.x62()*d.x22() + e.x63()*d.x32() + e.x64()*d.x42() + e.x65()*d.x52() + e.x66()*d.x62(), e.x61()*d.x13() + e.x62()*d.x23() + e.x63()*d.x33() + e.x64()*d.x43() + e.x65()*d.x53() + e.x66()*d.x63(),
+            false); //already transformed
+}
+
+
 //misc
 inline int constexpr mandel6x3_component_count = 18;
 
+}

--- a/p3a_mandel6x6.hpp
+++ b/p3a_mandel6x6.hpp
@@ -27,31 +27,25 @@ namespace p3a {
 /******************************************************************/
 /******************************************************************/
 template <class T>
-class Mandel6x6
+class mandel6x6
 /** 
  * Represents a 4th order tensor as a 6x6 Mandel array
  */
 /******************************************************************/
 {
- T x11,x12,x13,x14,x15,x16,
-   x21,x22,x23,x24,x25,x26,
-   x31,x32,x33,x34,x35,x36,
-   x41,x42,x43,x44,x45,x46,
-   x51,x52,x53,x54,x55,x56,
-   x61,x62,x63,x64,x65,x66;
+ T m_x11,m_x12,m_x13,m_x14,m_x15,m_x16,
+   m_x21,m_x22,m_x23,m_x24,m_x25,m_x26,
+   m_x31,m_x32,m_x33,m_x34,m_x35,m_x36,
+   m_x41,m_x42,m_x43,m_x44,m_x45,m_x46,
+   m_x51,m_x52,m_x53,m_x54,m_x55,m_x56,
+   m_x61,m_x62,m_x63,m_x64,m_x65,m_x66;
  bool applyTransform;
 
- template<class T>
- P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static
- T r2() {std::sqrt(T(2.0));}
+ static const T r2 = square_root(T(2.0));
 
- template<class T>
- P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static
- T r2i() {T(1.0)/std::sqrt(T(2.0));}
+ static const T r2i = T(1.0)/square_root(T(2.0));
 
- template<class T>
- P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr static 
- T two() {T(2.0);}
+ static const T two = T(2.0);
 
  public:
   /**** constructors, destructors, and assigns ****/
@@ -66,12 +60,12 @@ class Mandel6x6
       T const& X41, T const& X42, T const& X43, T const& X44, T const& X45, T const& X46,
       T const& X51, T const& X52, T const& X53, T const& X54, T const& X55, T const& X56,
       T const& X61, T const& X62, T const& X63, T const& X64, T const& X65, T const& X66):
-      x11(X11),x12(X12),x13(X13),x14(X14),x15(X15),x16(X16),
-      x21(X21),x22(X22),x23(X23),x24(X24),x25(X25),x26(X26),
-      x31(X31),x32(X32),x33(X33),x34(X34),x35(X35),x36(X36),
-      x41(X41),x42(X42),x43(X43),x44(X44),x45(X45),x46(X46),
-      x51(X51),x52(X52),x53(X53),x54(X54),x55(X55),x56(X56),
-      x61(X61),x62(X62),x63(X63),x64(X64),x65(X65),x66(X66),
+      m_x11(X11),m_x12(X12),m_x13(X13),m_x14(X14),m_x15(X15),m_x16(X16),
+      m_x21(X21),m_x22(X22),m_x23(X23),m_x24(X24),m_x25(X25),m_x26(X26),
+      m_x31(X31),m_x32(X32),m_x33(X33),m_x34(X34),m_x35(X35),m_x36(X36),
+      m_x41(X41),m_x42(X42),m_x43(X43),m_x44(X44),m_x45(X45),m_x46(X46),
+      m_x51(X51),m_x52(X52),m_x53(X53),m_x54(X54),m_x55(X55),m_x56(X56),
+      m_x61(X61),m_x62(X62),m_x63(X63),m_x64(X64),m_x65(X65),m_x66(X66),
        applyTransform(true)
   {
     if (applyTransform)
@@ -87,12 +81,12 @@ class Mandel6x6
       T const& X51, T const& X52, T const& X53, T const& X54, T const& X55, T const& X56,
       T const& X61, T const& X62, T const& X63, T const& X64, T const& X65, T const& X66, 
       bool const& Xform):
-    x11(X11),x12(X12),x13(X13),x14(X14),x15(X15),x16(X16),
-    x21(X21),x22(X22),x23(X23),x24(X24),x25(X25),x26(X26),
-    x31(X31),x32(X32),x33(X33),x34(X34),x35(X35),x36(X36),
-    x41(X41),x42(X42),x43(X43),x44(X44),x45(X45),x46(X46),
-    x51(X51),x52(X52),x53(X53),x54(X54),x55(X55),x56(X56),
-    x61(X61),x62(X62),x63(X63),x64(X64),x65(X65),x66(X66),
+    m_x11(X11),m_x12(X12),m_x13(X13),m_x14(X14),m_x15(X15),m_x16(X16),
+    m_x21(X21),m_x22(X22),m_x23(X23),m_x24(X24),m_x25(X25),m_x26(X26),
+    m_x31(X31),m_x32(X32),m_x33(X33),m_x34(X34),m_x35(X35),m_x36(X36),
+    m_x41(X41),m_x42(X42),m_x43(X43),m_x44(X44),m_x45(X45),m_x46(X46),
+    m_x51(X51),m_x52(X52),m_x53(X53),m_x54(X54),m_x55(X55),m_x56(X56),
+    m_x61(X61),m_x62(X62),m_x63(X63),m_x64(X64),m_x65(X65),m_x66(X66),
     applyTransform(Xform)
   {
     if (applyTransform)
@@ -102,12 +96,12 @@ class Mandel6x6
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   mandel6x6(
       static_matrix<T,6,6> const& X, bool const& Xform):
-    x11(X(0,0)),x12(X(0,1)),x13(X(0,2)),x14(X(0,3)),x15(X(0,4)),x16(X(0,5)),
-    x21(X(1,0)),x22(X(1,1)),x23(X(1,2)),x24(X(1,3)),x25(X(1,4)),x26(X(1,5)),
-    x31(X(2,0)),x32(X(2,1)),x33(X(2,2)),x34(X(2,3)),x35(X(2,4)),x36(X(2,5)),
-    x41(X(3,0)),x42(X(3,1)),x43(X(3,2)),x44(X(3,3)),x45(X(3,4)),x46(X(3,5)),
-    x51(X(4,0)),x52(X(4,1)),x53(X(4,2)),x54(X(4,3)),x55(X(4,4)),x56(X(4,5)),
-    x61(X(5,0)),x62(X(5,1)),x63(X(5,2)),x64(X(5,3)),x65(X(5,4)),x66(X(5,5)),
+    m_x11(X(0,0)),m_x12(X(0,1)),m_x13(X(0,2)),m_x14(X(0,3)),m_x15(X(0,4)),m_x16(X(0,5)),
+    m_x21(X(1,0)),m_x22(X(1,1)),m_x23(X(1,2)),m_x24(X(1,3)),m_x25(X(1,4)),m_x26(X(1,5)),
+    m_x31(X(2,0)),m_x32(X(2,1)),m_x33(X(2,2)),m_x34(X(2,3)),m_x35(X(2,4)),m_x36(X(2,5)),
+    m_x41(X(3,0)),m_x42(X(3,1)),m_x43(X(3,2)),m_x44(X(3,3)),m_x45(X(3,4)),m_x46(X(3,5)),
+    m_x51(X(4,0)),m_x52(X(4,1)),m_x53(X(4,2)),m_x54(X(4,3)),m_x55(X(4,4)),m_x56(X(4,5)),
+    m_x61(X(5,0)),m_x62(X(5,1)),m_x63(X(5,2)),m_x64(X(5,3)),m_x65(X(5,4)),m_x66(X(5,5)),
     applyTransform(Xform)
   {
     if (applyTransform)
@@ -117,12 +111,12 @@ class Mandel6x6
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   mandel6x6(
       static_matrix<T,6,6> const& X):
-    x11(X(0,0)),x12(X(0,1)),x13(X(0,2)),x14(X(0,3)),x15(X(0,4)),x16(X(0,5)),
-    x21(X(1,0)),x22(X(1,1)),x23(X(1,2)),x24(X(1,3)),x25(X(1,4)),x26(X(1,5)),
-    x31(X(2,0)),x32(X(2,1)),x33(X(2,2)),x34(X(2,3)),x35(X(2,4)),x36(X(2,5)),
-    x41(X(3,0)),x42(X(3,1)),x43(X(3,2)),x44(X(3,3)),x45(X(3,4)),x46(X(3,5)),
-    x51(X(4,0)),x52(X(4,1)),x53(X(4,2)),x54(X(4,3)),x55(X(4,4)),x56(X(4,5)),
-    x61(X(5,0)),x62(X(5,1)),x63(X(5,2)),x64(X(5,3)),x65(X(5,4)),x66(X(5,5)),
+    m_x11(X(0,0)),m_x12(X(0,1)),m_x13(X(0,2)),m_x14(X(0,3)),m_x15(X(0,4)),m_x16(X(0,5)),
+    m_x21(X(1,0)),m_x22(X(1,1)),m_x23(X(1,2)),m_x24(X(1,3)),m_x25(X(1,4)),m_x26(X(1,5)),
+    m_x31(X(2,0)),m_x32(X(2,1)),m_x33(X(2,2)),m_x34(X(2,3)),m_x35(X(2,4)),m_x36(X(2,5)),
+    m_x41(X(3,0)),m_x42(X(3,1)),m_x43(X(3,2)),m_x44(X(3,3)),m_x45(X(3,4)),m_x46(X(3,5)),
+    m_x51(X(4,0)),m_x52(X(4,1)),m_x53(X(4,2)),m_x54(X(4,3)),m_x55(X(4,4)),m_x56(X(4,5)),
+    m_x61(X(5,0)),m_x62(X(5,1)),m_x63(X(5,2)),m_x64(X(5,3)),m_x65(X(5,4)),m_x66(X(5,5)),
     applyTransform(true)
   {
     this->MandelXform();
@@ -130,152 +124,152 @@ class Mandel6x6
 
   //return by mandel index 1-6,1-6
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x11() const { return x11; }
+  T const& x11() const { return m_x11; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x12() const { return x12; }
+  T const& x12() const { return m_x12; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x13() const { return x13; }
+  T const& x13() const { return m_x13; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x14() const { return x14; }
+  T const& x14() const { return m_x14; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x15() const { return x15; }
+  T const& x15() const { return m_x15; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x16() const { return x16; }
+  T const& x16() const { return m_x16; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x21() const { return x21; }
+  T const& x21() const { return m_x21; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x22() const { return x22; }
+  T const& x22() const { return m_x22; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x23() const { return x23; }
+  T const& x23() const { return m_x23; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x24() const { return x24; }
+  T const& x24() const { return m_x24; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x25() const { return x25; }
+  T const& x25() const { return m_x25; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x26() const { return x26; }
+  T const& x26() const { return m_x26; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x31() const { return x31; }
+  T const& x31() const { return m_x31; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x32() const { return x32; }
+  T const& x32() const { return m_x32; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x33() const { return x33; }
+  T const& x33() const { return m_x33; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x34() const { return x34; }
+  T const& x34() const { return m_x34; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x35() const { return x35; }
+  T const& x35() const { return m_x35; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x36() const { return x36; }
+  T const& x36() const { return m_x36; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x41() const { return x41; }
+  T const& x41() const { return m_x41; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x42() const { return x42; }
+  T const& x42() const { return m_x42; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x43() const { return x43; }
+  T const& x43() const { return m_x43; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x44() const { return x44; }
+  T const& x44() const { return m_x44; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x45() const { return x45; }
+  T const& x45() const { return m_x45; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x46() const { return x46; }
+  T const& x46() const { return m_x46; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x51() const { return x51; }
+  T const& x51() const { return m_x51; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x52() const { return x52; }
+  T const& x52() const { return m_x52; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x53() const { return x53; }
+  T const& x53() const { return m_x53; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x54() const { return x54; }
+  T const& x54() const { return m_x54; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x55() const { return x55; }
+  T const& x55() const { return m_x55; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x56() const { return x56; }
+  T const& x56() const { return m_x56; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x61() const { return x61; }
+  T const& x61() const { return m_x61; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x62() const { return x62; }
+  T const& x62() const { return m_x62; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x63() const { return x63; }
+  T const& x63() const { return m_x63; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x64() const { return x64; }
+  T const& x64() const { return m_x64; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x65() const { return x65; }
+  T const& x65() const { return m_x65; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T const& x66() const { return x66; }
+  T const& x66() const { return m_x66; }
 
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x11() { return x11; }
+  T& x11() { return m_x11; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x12() { return x12; }
+  T& x12() { return m_x12; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x13() { return x13; }
+  T& x13() { return m_x13; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x14() { return x14; }
+  T& x14() { return m_x14; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x15() { return x15; }
+  T& x15() { return m_x15; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x16() { return x16; }
+  T& x16() { return m_x16; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x21() { return x21; }
+  T& x21() { return m_x21; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x22() { return x22; }
+  T& x22() { return m_x22; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x23() { return x23; }
+  T& x23() { return m_x23; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x24() { return x24; }
+  T& x24() { return m_x24; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x25() { return x25; }
+  T& x25() { return m_x25; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x26() { return x26; }
+  T& x26() { return m_x26; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x31() { return x31; }
+  T& x31() { return m_x31; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x32() { return x32; }
+  T& x32() { return m_x32; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x33() { return x33; }
+  T& x33() { return m_x33; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x34() { return x34; }
+  T& x34() { return m_x34; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x35() { return x35; }
+  T& x35() { return m_x35; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x36() { return x36; }
+  T& x36() { return m_x36; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x41() { return x41; }
+  T& x41() { return m_x41; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x42() { return x42; }
+  T& x42() { return m_x42; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x43() { return x43; }
+  T& x43() { return m_x43; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x44() { return x44; }
+  T& x44() { return m_x44; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x45() { return x45; }
+  T& x45() { return m_x45; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x46() { return x46; }
+  T& x46() { return m_x46; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x51() { return x51; }
+  T& x51() { return m_x51; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x52() { return x52; }
+  T& x52() { return m_x52; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x53() { return x53; }
+  T& x53() { return m_x53; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x54() { return x54; }
+  T& x54() { return m_x54; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x55() { return x55; }
+  T& x55() { return m_x55; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x56() { return x56; }
+  T& x56() { return m_x56; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x61() { return x61; }
+  T& x61() { return m_x61; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x62() { return x62; }
+  T& x62() { return m_x62; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x63() { return x63; }
+  T& x63() { return m_x63; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x64() { return x64; }
+  T& x64() { return m_x64; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x65() { return x65; }
+  T& x65() { return m_x65; }
   [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  T& x66() { return x66; }
+  T& x66() { return m_x66; }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
   mandel6x6<T> zero()
   {
     return mandel6x6<T>(
@@ -288,7 +282,7 @@ class Mandel6x6
         false);
   }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
   mandel6x6<T> identity()
   {
     return mandel6x6<T>(
@@ -301,28 +295,28 @@ class Mandel6x6
         true);
   }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   void MandelXform()
   {
-                              x14*=r2,x15*=r2,x16*=r2;
-                              x24*=r2,x25*=r2,x26*=r2;
-                              x34*=r2,x35*=r2,x36*=r2;
-      x41*=r2,x42*=r2,x43*=r2,x44*=two,x45*=two,x46*=two;
-      x51*=r2,x52*=r2,x53*=r2,x54*=two,x55*=two,x56*=two;
-      x61*=r2,x62*=r2,x63*=r2,x64*=two,x65*=two,x66*=two;
+                              m_x14*=r2,m_x15*=r2,m_x16*=r2;
+                              m_x24*=r2,m_x25*=r2,m_x26*=r2;
+                              m_x34*=r2,m_x35*=r2,m_x36*=r2;
+      m_x41*=r2,m_x42*=r2,m_x43*=r2,m_x44*=two,m_x45*=two,m_x46*=two;
+      m_x51*=r2,m_x52*=r2,m_x53*=r2,m_x54*=two,m_x55*=two,m_x56*=two;
+      m_x61*=r2,m_x62*=r2,m_x63*=r2,m_x64*=two,m_x65*=two,m_x66*=two;
   }
 
-  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   void invMandelXform()
   {
-                              x14/=r2,x15/=r2,x16/=r2;
-                              x24/=r2,x25/=r2,x26/=r2;
-                              x34/=r2,x35/=r2,x36/=r2;
-      x41/=r2,x42/=r2,x43/=r2,x44/=two,x45/=two,x46/=two;
-      x51/=r2,x52/=r2,x53/=r2,x54/=two,x55/=two,x56/=two;
-      x61/=r2,x62/=r2,x63/=r2,x64/=two,x65/=two,x66/=two;
-  }
-
+                              m_x14/=r2,m_x15/=r2,m_x16/=r2;
+                              m_x24/=r2,m_x25/=r2,m_x26/=r2;
+                              m_x34/=r2,m_x35/=r2,m_x36/=r2;
+      m_x41/=r2,m_x42/=r2,m_x43/=r2,m_x44/=two,m_x45/=two,m_x46/=two;
+      m_x51/=r2,m_x52/=r2,m_x53/=r2,m_x54/=two,m_x55/=two,m_x56/=two;
+      m_x61/=r2,m_x62/=r2,m_x63/=r2,m_x64/=two,m_x65/=two,m_x66/=two;
+  }                        
+                             
 };
 
 /***************************************************************************** 
@@ -366,7 +360,7 @@ operator/(
         mandel6x6<A> const& a, 
         B const& c)
 {
-    return mandel6x6<decltype<(a.x11() / c)>(
+    return mandel6x6<decltype(A()*B())>(
             a.x11()/c, a.x12()/c, a.x13()/c, a.x14()/c, a.x15()/c, a.x16()/c,
             a.x21()/c, a.x22()/c, a.x23()/c, a.x24()/c, a.x25()/c, a.x26()/c,
             a.x31()/c, a.x32()/c, a.x33()/c, a.x34()/c, a.x35()/c, a.x36()/c,
@@ -378,7 +372,7 @@ operator/(
 
 //division /= by constant
 template <class A>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator/=(
         mandel6x6<A>& a, 
         A const& c)
@@ -423,7 +417,7 @@ void operator/=(
 
 //multiplication *= by constant
 template <class A>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator*=(
         mandel6x6<A>& a, 
         A const& c)
@@ -468,7 +462,7 @@ void operator*=(
 
 //mandel6x6 += addition
 template <class T>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator+=(
     mandel6x6<T>& a, 
     mandel6x6<T> const& b)
@@ -513,7 +507,7 @@ void operator+=(
 
 //mandel6x6 -= subtraction
 template <class T>
-[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
 void operator-=(
     mandel6x6<T>& a, 
     mandel6x6<T> const& b)
@@ -711,13 +705,13 @@ mandel6x6<U> Inverse(
         for(col=0;col<n;col++)
         {
             //find max value of each row
-            if(std::abs(w(row,col))>std::abs(wmax))
+            if(absolute_value(w(row,col))>absolut_value(wmax))
             {
                 wmax = w(row,col);
             }
         }
         //if the row is empty: error
-        if(std::abs(wmax) <= minimum<U>();
+        if(absolute_value(wmax) <= minimum<U>())
         {
            icond = 1;
            throw std::invalid_argument(
@@ -739,9 +733,9 @@ mandel6x6<U> Inverse(
         startrow = -1;
         for(row=col;row<n;row++)
         {
-            if(std::abs(w(row,col))>wmax)
+            if(absolute_value(w(row,col))>wmax)
             {
-                wmax = std::abs(w(row,col));
+                wmax = absolute_value(w(row,col));
                 
                 startrow=row;
             }
@@ -757,7 +751,7 @@ mandel6x6<U> Inverse(
         wmax = w(col,col);
 
         //check for ill conditioned tensor
-        if(std::abs(wmax) < wcond)
+        if(absolute_value(wmax) < wcond)
         {
             icond = 1;
             throw std::invalid_argument(
@@ -799,36 +793,36 @@ mandel6x6<T> MandelTransformation(
         a.xx()*a.xx(),
         a.xy()*a.xy(),
         a.xz()*a.xz(),
-        a.xy()*a.xz()*r2,
-        a.xx()*a.xz()*r2,
-        a.xx()*a.xy()*r2,
+        a.xy()*a.xz()*a.r2,
+        a.xx()*a.xz()*a.r2,
+        a.xx()*a.xy()*a.r2,
         a.yx()*a.yx(),
         a.yy()*a.yy(),
         a.yz()*a.yz(),
-        a.yy()*a.yz()*r2,
-        a.yx()*a.yz()*r2,
-        a.yx()*a.yy()*r2,
+        a.yy()*a.yz()*a.r2,
+        a.yx()*a.yz()*a.r2,
+        a.yx()*a.yy()*a.r2,
         a.zx()*a.zx(),
         a.zy()*a.zy(),
         a.zz()*a.zz(),
-        a.zy()*a.zz()*r2,
-        a.zx()*a.zz()*r2,
-        a.zx()*a.zy()*r2,
-        a.yx()*a.zx()*r2,
-        a.yy()*a.zy()*r2,
-        a.yz()*a.zz()*r2,
+        a.zy()*a.zz()*a.r2,
+        a.zx()*a.zz()*a.r2,
+        a.zx()*a.zy()*a.r2,
+        a.yx()*a.zx()*a.r2,
+        a.yy()*a.zy()*a.r2,
+        a.yz()*a.zz()*a.r2,
         a.yy()*a.zz()+a.yz()*a.zy(),
         a.yz()*a.zx()+a.yx()*a.zz(),
         a.yx()*a.zy()+a.yy()*a.zx(),
-        a.xx()*a.zx()*r2,
-        a.xy()*a.zy()*r2,
-        a.xz()*a.zz()*r2,
+        a.xx()*a.zx()*a.r2,
+        a.xy()*a.zy()*a.r2,
+        a.xz()*a.zz()*a.r2,
         a.zy()*a.xz()+a.zz()*a.xy(),
         a.zz()*a.xx()+a.zx()*a.xz(),
         a.zx()*a.xy()+a.zy()*a.xx(),
-        a.xx()*a.yx()*r2,
-        a.xy()*a.yy()*r2,
-        a.xz()*a.yz()*r2,
+        a.xx()*a.yx()*a.r2,
+        a.xy()*a.yy()*a.r2,
+        a.xz()*a.yz()*a.r2,
         a.xy()*a.yz()+a.xz()*a.yy(),
         a.xz()*a.yx()+a.xx()*a.yz(),
         a.xx()*a.yy()+a.xy()*a.yx(),
@@ -875,7 +869,7 @@ auto operator*(
     mandel6x6<T> const &C, 
     symmetric3x3<U> const &s)
 {
-    v = mandel6x1<T>(s);
+    mandel6x1<T> v(s);
     return C*v;
 }
 
@@ -899,3 +893,4 @@ auto operator*(
 //misc
 inline int constexpr mandel6x6_component_count = 36;
 
+}

--- a/p3a_mandel6x6.hpp
+++ b/p3a_mandel6x6.hpp
@@ -41,11 +41,11 @@ class mandel6x6
    m_x61,m_x62,m_x63,m_x64,m_x65,m_x66;
  bool applyTransform;
 
- static const T r2 = square_root(T(2.0));
+ static constexpr T r2 = std::sqrt(T(2.0));
 
- static const T r2i = T(1.0)/square_root(T(2.0));
+ static constexpr T r2i = T(1.0)/std::sqrt(T(2.0));
 
- static const T two = T(2.0);
+ static constexpr T two = T(2.0);
 
  public:
   /**** constructors, destructors, and assigns ****/
@@ -614,7 +614,7 @@ T trace(
 //inverse
 template <class U>
 P3A_NEVER_INLINE 
-mandel6x6<U> Inverse(
+mandel6x6<U> inverse(
     mandel6x6<U> const &V)
 {
     /**************************************************************************
@@ -638,16 +638,15 @@ mandel6x6<U> Inverse(
     U vval=0;
     U wmax =0;
     U fac =0; 
-    U wcond = minimum<U>();
+    U wcond = minimum_value<U>();
     static_matrix<U,6,6> w;
     static_matrix<U,6,6> ainv;
     static_vector<U,6> dummy;
 
      
-    dummy.zeros();
-    ainv.zeros();
-    ainv.identity();
-    w.zeros();
+    dummy = dummy.zero();
+    ainv = ainv.identity();
+    w = w.zero();
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Initialize and allocate
@@ -656,47 +655,47 @@ mandel6x6<U> Inverse(
     // while converting input 6x6 tensor T from Mandel form to normal form
     
     // Row 1
-    w(0,0)=T.x11;
-    w(0,1)=T.x12;
-    w(0,2)=T.x13;
-    w(0,3)=T.x14;
-    w(0,4)=T.x15;
-    w(0,5)=T.x16;
+    w(0,0)=T.x11();
+    w(0,1)=T.x12();
+    w(0,2)=T.x13();
+    w(0,3)=T.x14();
+    w(0,4)=T.x15();
+    w(0,5)=T.x16();
     // Row 2
-    w(1,0)=T.x21;
-    w(1,1)=T.x22;
-    w(1,2)=T.x23;
-    w(1,3)=T.x24;
-    w(1,4)=T.x25;
-    w(1,5)=T.x26;
+    w(1,0)=T.x21();
+    w(1,1)=T.x22();
+    w(1,2)=T.x23();
+    w(1,3)=T.x24();
+    w(1,4)=T.x25();
+    w(1,5)=T.x26();
     //Row 3
-    w(2,0)=T.x31;
-    w(2,1)=T.x32;
-    w(2,2)=T.x33;
-    w(2,3)=T.x34;
-    w(2,4)=T.x35;
-    w(2,5)=T.x36;
+    w(2,0)=T.x31();
+    w(2,1)=T.x32();
+    w(2,2)=T.x33();
+    w(2,3)=T.x34();
+    w(2,4)=T.x35();
+    w(2,5)=T.x36();
     //Row 4
-    w(3,0)=T.x41;
-    w(3,1)=T.x42;
-    w(3,2)=T.x43;
-    w(3,3)=T.x44;
-    w(3,4)=T.x45;
-    w(3,5)=T.x46;
+    w(3,0)=T.x41();
+    w(3,1)=T.x42();
+    w(3,2)=T.x43();
+    w(3,3)=T.x44();
+    w(3,4)=T.x45();
+    w(3,5)=T.x46();
     //Row 5
-    w(4,0)=T.x51;
-    w(4,1)=T.x52;
-    w(4,2)=T.x53;
-    w(4,3)=T.x54;
-    w(4,4)=T.x55;
-    w(4,5)=T.x56;
+    w(4,0)=T.x51();
+    w(4,1)=T.x52();
+    w(4,2)=T.x53();
+    w(4,3)=T.x54();
+    w(4,4)=T.x55();
+    w(4,5)=T.x56();
     //Row 6
-    w(5,0)=T.x61;
-    w(5,1)=T.x62;
-    w(5,2)=T.x63;
-    w(5,3)=T.x64;
-    w(5,4)=T.x65;
-    w(5,5)=T.x66;
+    w(5,0)=T.x61();
+    w(5,1)=T.x62();
+    w(5,2)=T.x63();
+    w(5,3)=T.x64();
+    w(5,4)=T.x65();
+    w(5,5)=T.x66();
 
     //Locate maximum value in each row and normalize by that value
     for(row=0;row<n;row++)
@@ -705,13 +704,13 @@ mandel6x6<U> Inverse(
         for(col=0;col<n;col++)
         {
             //find max value of each row
-            if(absolute_value(w(row,col))>absolut_value(wmax))
+            if(absolute_value(w(row,col))>absolute_value(wmax))
             {
                 wmax = w(row,col);
             }
         }
         //if the row is empty: error
-        if(absolute_value(wmax) <= minimum<U>())
+        if(absolute_value(wmax) <= minimum_value<U>())
         {
            icond = 1;
            throw std::invalid_argument(
@@ -741,12 +740,12 @@ mandel6x6<U> Inverse(
             }
         }
 
-        for(int j=col;j<n;j++) dummy(j) = w(col,j);
+        for(int j=col;j<n;j++) dummy[j] = w(col,j);
         for(int j=col;j<n;j++) w(col,j) = w(startrow,j);
-        for(int j=col;j<n;j++) w(startrow,j) = dummy(j);
-        for(int j=0;j<n;j++) dummy(j) = ainv(col,j);
+        for(int j=col;j<n;j++) w(startrow,j) = dummy[j];
+        for(int j=0;j<n;j++) dummy[j] = ainv(col,j);
         for(int j=0;j<n;j++) ainv(col,j) = ainv(startrow,j);
-        for(int j=0;j<n;j++) ainv(startrow,j) = dummy(j);
+        for(int j=0;j<n;j++) ainv(startrow,j) = dummy[j];
 
         wmax = w(col,col);
 
@@ -759,15 +758,15 @@ mandel6x6<U> Inverse(
         }
 
         row = col;
-        for(int j=col;j<n;j++) w[row,j] /= wmax;
-        for(int k=0;k<n;k++) ainv[row,k] /= wmax;
+        for(int j=col;j<n;j++) w(row,j) /= wmax;
+        for(int k=0;k<n;k++) ainv(row,k) /= wmax;
 
         for(row=0;row<n;row++)
         {
             if(row == col) continue;
-            fac = w[row*n+col];
-            for(int j=col;j<n;j++) w[row,j] -= fac * w[col,j];
-            for(int k=0;k<n;k++) ainv[row,k] -= fac * ainv[col,k];
+            fac = w(row,col);
+            for(int j=col;j<n;j++) w(row,j) -= fac * w(col,j);
+            for(int k=0;k<n;k++) ainv(row,k) -= fac * ainv(col,k);
         }//end row loop
 
     }//end col loop
@@ -845,6 +844,53 @@ mandel6x6<T> transpose(
         false); //already transformed
 }
 
+/** Tensor multiplication: Mandel6x6 * Mandel6x6 **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x6<T> const &e,
+    mandel6x6<U> const &d)
+{
+    return mandel6x6<decltype(e.x11()*d.x11())>(
+            e.x11()*d.x11() + e.x12()*d.x21() + e.x13()*d.x31() + e.x14()*d.x41() + e.x15()*d.x51() + e.x16()*d.x61(),
+            e.x11()*d.x12() + e.x12()*d.x22() + e.x13()*d.x32() + e.x14()*d.x42() + e.x15()*d.x52() + e.x16()*d.x62(),
+            e.x11()*d.x13() + e.x12()*d.x23() + e.x13()*d.x33() + e.x14()*d.x43() + e.x15()*d.x53() + e.x16()*d.x63(),
+            e.x11()*d.x14() + e.x12()*d.x24() + e.x13()*d.x34() + e.x14()*d.x44() + e.x15()*d.x54() + e.x16()*d.x64(),
+            e.x11()*d.x15() + e.x12()*d.x25() + e.x13()*d.x35() + e.x14()*d.x45() + e.x15()*d.x55() + e.x16()*d.x65(),
+            e.x11()*d.x16() + e.x12()*d.x26() + e.x13()*d.x36() + e.x14()*d.x46() + e.x15()*d.x56() + e.x16()*d.x66(),
+            e.x21()*d.x11() + e.x22()*d.x21() + e.x23()*d.x31() + e.x24()*d.x41() + e.x25()*d.x51() + e.x26()*d.x61(),
+            e.x21()*d.x12() + e.x22()*d.x22() + e.x23()*d.x32() + e.x24()*d.x42() + e.x25()*d.x52() + e.x26()*d.x62(),
+            e.x21()*d.x13() + e.x22()*d.x23() + e.x23()*d.x33() + e.x24()*d.x43() + e.x25()*d.x53() + e.x26()*d.x63(),
+            e.x21()*d.x14() + e.x22()*d.x24() + e.x23()*d.x34() + e.x24()*d.x44() + e.x25()*d.x54() + e.x26()*d.x64(),
+            e.x21()*d.x15() + e.x22()*d.x25() + e.x23()*d.x35() + e.x24()*d.x45() + e.x25()*d.x55() + e.x26()*d.x65(),
+            e.x21()*d.x16() + e.x22()*d.x26() + e.x23()*d.x36() + e.x24()*d.x46() + e.x25()*d.x56() + e.x26()*d.x66(),
+            e.x31()*d.x11() + e.x32()*d.x21() + e.x33()*d.x31() + e.x34()*d.x41() + e.x35()*d.x51() + e.x36()*d.x61(),
+            e.x31()*d.x12() + e.x32()*d.x22() + e.x33()*d.x32() + e.x34()*d.x42() + e.x35()*d.x52() + e.x36()*d.x62(),
+            e.x31()*d.x13() + e.x32()*d.x23() + e.x33()*d.x33() + e.x34()*d.x43() + e.x35()*d.x53() + e.x36()*d.x63(),
+            e.x31()*d.x14() + e.x32()*d.x24() + e.x33()*d.x34() + e.x34()*d.x44() + e.x35()*d.x54() + e.x36()*d.x64(),
+            e.x31()*d.x15() + e.x32()*d.x25() + e.x33()*d.x35() + e.x34()*d.x45() + e.x35()*d.x55() + e.x36()*d.x65(),
+            e.x31()*d.x16() + e.x32()*d.x26() + e.x33()*d.x36() + e.x34()*d.x46() + e.x35()*d.x56() + e.x36()*d.x66(),
+            e.x41()*d.x11() + e.x42()*d.x21() + e.x43()*d.x31() + e.x44()*d.x41() + e.x45()*d.x51() + e.x46()*d.x61(),
+            e.x41()*d.x12() + e.x42()*d.x22() + e.x43()*d.x32() + e.x44()*d.x42() + e.x45()*d.x52() + e.x46()*d.x62(),
+            e.x41()*d.x13() + e.x42()*d.x23() + e.x43()*d.x33() + e.x44()*d.x43() + e.x45()*d.x53() + e.x46()*d.x63(),
+            e.x41()*d.x14() + e.x42()*d.x24() + e.x43()*d.x34() + e.x44()*d.x44() + e.x45()*d.x54() + e.x46()*d.x64(),
+            e.x41()*d.x15() + e.x42()*d.x25() + e.x43()*d.x35() + e.x44()*d.x45() + e.x45()*d.x55() + e.x46()*d.x65(),
+            e.x41()*d.x16() + e.x42()*d.x26() + e.x43()*d.x36() + e.x44()*d.x46() + e.x45()*d.x56() + e.x46()*d.x66(),
+            e.x51()*d.x11() + e.x52()*d.x21() + e.x53()*d.x31() + e.x54()*d.x41() + e.x55()*d.x51() + e.x56()*d.x61(),
+            e.x51()*d.x12() + e.x52()*d.x22() + e.x53()*d.x32() + e.x54()*d.x42() + e.x55()*d.x52() + e.x56()*d.x62(),
+            e.x51()*d.x13() + e.x52()*d.x23() + e.x53()*d.x33() + e.x54()*d.x43() + e.x55()*d.x53() + e.x56()*d.x63(),
+            e.x51()*d.x14() + e.x52()*d.x24() + e.x53()*d.x34() + e.x54()*d.x44() + e.x55()*d.x54() + e.x56()*d.x64(),
+            e.x51()*d.x15() + e.x52()*d.x25() + e.x53()*d.x35() + e.x54()*d.x45() + e.x55()*d.x55() + e.x56()*d.x65(),
+            e.x51()*d.x16() + e.x52()*d.x26() + e.x53()*d.x36() + e.x54()*d.x46() + e.x55()*d.x56() + e.x56()*d.x66(),
+            e.x61()*d.x11() + e.x62()*d.x21() + e.x63()*d.x31() + e.x64()*d.x41() + e.x65()*d.x51() + e.x66()*d.x61(),
+            e.x61()*d.x12() + e.x62()*d.x22() + e.x63()*d.x32() + e.x64()*d.x42() + e.x65()*d.x52() + e.x66()*d.x62(),
+            e.x61()*d.x13() + e.x62()*d.x23() + e.x63()*d.x33() + e.x64()*d.x43() + e.x65()*d.x53() + e.x66()*d.x63(),
+            e.x61()*d.x14() + e.x62()*d.x24() + e.x63()*d.x34() + e.x64()*d.x44() + e.x65()*d.x54() + e.x66()*d.x64(),
+            e.x61()*d.x15() + e.x62()*d.x25() + e.x63()*d.x35() + e.x64()*d.x45() + e.x65()*d.x55() + e.x66()*d.x65(),
+            e.x61()*d.x16() + e.x62()*d.x26() + e.x63()*d.x36() + e.x64()*d.x46() + e.x65()*d.x56() + e.x66()*d.x66(),
+            false);//already transformed
+}
+
 /** Tensor multiply mandel6x6 (6x6) by mandel6x1 (6x1) **/
 template <class T, class U>
 [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
@@ -852,7 +898,7 @@ auto operator*(
     mandel6x6<T> const &C,
     mandel6x1<U> const &v)
 {
-    return mandel6x1<decltype(C.x11*v.x1)>(
+    return mandel6x1<decltype(C.x11()*v.x1())>(
         (C.x11()*v.x1() + C.x12()*v.x2() + C.x13()*v.x3() + C.x14()*v.x4() + C.x15()*v.x5() + C.x16()*v.x6()),
         (C.x21()*v.x1() + C.x22()*v.x2() + C.x23()*v.x3() + C.x24()*v.x4() + C.x25()*v.x5() + C.x26()*v.x6()),
         (C.x31()*v.x1() + C.x32()*v.x2() + C.x33()*v.x3() + C.x34()*v.x4() + C.x35()*v.x5() + C.x36()*v.x6()),
@@ -870,6 +916,17 @@ auto operator*(
     symmetric3x3<U> const &s)
 {
     mandel6x1<T> v(s);
+    return C*v;
+}
+
+/** Tensor multiply Mandel6x6 (6x6) by symmetric3x3 (3x3) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x6<T> const &C, 
+    matrix3x3<U> const &s)
+{
+    mandel6x1<decltype(s.xx()*C.x11())> v(s);
     return C*v;
 }
 

--- a/p3a_mandel6x6.hpp
+++ b/p3a_mandel6x6.hpp
@@ -1,0 +1,733 @@
+#pragma once
+
+#include "p3a_macros.hpp"
+#include "p3a_diagonal3x3.hpp"
+#include "p3a_vector3.hpp"
+#include "p3a_symmetric3x3.hpp"
+#include "p3a_matrix3x3.hpp"
+#include "p3a_mandel6x1.hpp"
+/********************************* NOTES ************************************
+ * This header provides the class: 
+ *
+ * - `mandel6x6` (6x6) 4th order Tensor
+ *
+ * See additional notes in `p3a_mandel6x1.hpp`.
+ */
+
+namespace p3a {
+
+/******************************************************************/
+/******************************************************************/
+template <class T>
+class Mandel6x6
+/** 
+ * Represents a 4th order tensor as a 6x6 Mandel array
+ */
+/******************************************************************/
+{
+ T x11,x12,x13,x14,x15,x16,
+   x21,x22,x23,x24,x25,x26,
+   x31,x32,x33,x34,x35,x36,
+   x41,x42,x43,x44,x45,x46,
+   x51,x52,x53,x54,x55,x56,
+   x61,x62,x63,x64,x65,x66;
+ bool applyTransform;
+
+ const T r2 = std::sqrt(T(2.0));
+ const T r2i = T(1.0)/std::sqrt(T(2.0));
+ const T two = T(2.0);
+
+ public:
+  /**** constructors, destructors, and assigns ****/
+  P3A_ALWAYS_INLINE constexpr
+  mandel6x6() = default;
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x6(
+      T const& X11, T const& X12, T const& X13, T const& X14, T const& X15, T const& X16,
+      T const& X21, T const& X22, T const& X23, T const& X24, T const& X25, T const& X26,
+      T const& X31, T const& X32, T const& X33, T const& X34, T const& X35, T const& X36,
+      T const& X41, T const& X42, T const& X43, T const& X44, T const& X45, T const& X46,
+      T const& X51, T const& X52, T const& X53, T const& X54, T const& X55, T const& X56,
+      T const& X61, T const& X62, T const& X63, T const& X64, T const& X65, T const& X66):
+      x11(X11),x12(X12),x13(X13),x14(X14),x15(X15),x16(X16),
+      x21(X21),x22(X22),x23(X23),x24(X24),x25(X25),x26(X26),
+      x31(X31),x32(X32),x33(X33),x34(X34),x35(X35),x36(X36),
+      x41(X41),x42(X42),x43(X43),x44(X44),x45(X45),x46(X46),
+      x51(X51),x52(X52),x53(X53),x54(X54),x55(X55),x56(X56),
+      x61(X61),x62(X62),x63(X63),x64(X64),x65(X65),x66(X66),
+       applyTransform(true)
+  {
+    if (applyTransform)
+        this->MandelXform();
+  }
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x6(
+      T const& X11, T const& X12, T const& X13, T const& X14, T const& X15, T const& X16,
+      T const& X21, T const& X22, T const& X23, T const& X24, T const& X25, T const& X26,
+      T const& X31, T const& X32, T const& X33, T const& X34, T const& X35, T const& X36,
+      T const& X41, T const& X42, T const& X43, T const& X44, T const& X45, T const& X46,
+      T const& X51, T const& X52, T const& X53, T const& X54, T const& X55, T const& X56,
+      T const& X61, T const& X62, T const& X63, T const& X64, T const& X65, T const& X66, 
+      bool const& Xform):
+    x11(X11),x12(X12),x13(X13),x14(X14),x15(X15),x16(X16),
+    x21(X21),x22(X22),x23(X23),x24(X24),x25(X25),x26(X26),
+    x31(X31),x32(X32),x33(X33),x34(X34),x35(X35),x36(X36),
+    x41(X41),x42(X42),x43(X43),x44(X44),x45(X45),x46(X46),
+    x51(X51),x52(X52),x53(X53),x54(X54),x55(X55),x56(X56),
+    x61(X61),x62(X62),x63(X63),x64(X64),x65(X65),x66(X66),
+    applyTransform(Xform)
+  {
+    if (applyTransform)
+        this->MandelXform();
+  }
+
+  //return by mandel index 1-6
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x11() const { return x11; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x12() const { return x12; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x13() const { return x13; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x14() const { return x14; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x15() const { return x15; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x16() const { return x16; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x21() const { return x21; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x22() const { return x22; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x23() const { return x23; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x24() const { return x24; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x25() const { return x25; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x26() const { return x26; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x31() const { return x31; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x32() const { return x32; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x33() const { return x33; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x34() const { return x34; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x35() const { return x35; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x36() const { return x36; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x41() const { return x41; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x42() const { return x42; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x43() const { return x43; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x44() const { return x44; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x45() const { return x45; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x46() const { return x46; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x51() const { return x51; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x52() const { return x52; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x53() const { return x53; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x54() const { return x54; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x55() const { return x55; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x56() const { return x56; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x61() const { return x61; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x62() const { return x62; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x63() const { return x63; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x64() const { return x64; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x65() const { return x65; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T const& x66() const { return x66; }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x11() { return x11; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x12() { return x12; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x13() { return x13; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x14() { return x14; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x15() { return x15; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x16() { return x16; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x21() { return x21; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x22() { return x22; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x23() { return x23; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x24() { return x24; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x25() { return x25; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x26() { return x26; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x31() { return x31; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x32() { return x32; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x33() { return x33; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x34() { return x34; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x35() { return x35; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x36() { return x36; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x41() { return x41; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x42() { return x42; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x43() { return x43; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x44() { return x44; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x45() { return x45; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x46() { return x46; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x51() { return x51; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x52() { return x52; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x53() { return x53; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x54() { return x54; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x55() { return x55; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x56() { return x56; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x61() { return x61; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x62() { return x62; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x63() { return x63; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x64() { return x64; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x65() { return x65; }
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  T& x66() { return x66; }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  mandel6x6<T> zero()
+  {
+    return mandel6x6<T>(
+        T(0), T(0), T(0), T(0), T(0), T(0),
+        T(0), T(0), T(0), T(0), T(0), T(0),
+        T(0), T(0), T(0), T(0), T(0), T(0),
+        T(0), T(0), T(0), T(0), T(0), T(0),
+        T(0), T(0), T(0), T(0), T(0), T(0),
+        T(0), T(0), T(0), T(0), T(0), T(0),
+        false);
+  }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE static constexpr
+  mandel6x6<T> identity()
+  {
+    return mandel6x6<T>(
+        T(1), T(0), T(0), T(0), T(0), T(0),
+        T(0), T(1), T(0), T(0), T(0), T(0),
+        T(0), T(0), T(1), T(0), T(0), T(0),
+        T(0), T(0), T(0), T(1), T(0), T(0),
+        T(0), T(0), T(0), T(0), T(1), T(0),
+        T(0), T(0), T(0), T(0), T(0), T(1),
+        true);
+  }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  void MandelXform()
+  {
+                              x14*=r2,x15*=r2,x16*=r2;
+                              x24*=r2,x25*=r2,x26*=r2;
+                              x34*=r2,x35*=r2,x36*=r2;
+      x41*=r2,x42*=r2,x43*=r2,x44*=two,x45*=two,x46*=two;
+      x51*=r2,x52*=r2,x53*=r2,x54*=two,x55*=two,x56*=two;
+      x61*=r2,x62*=r2,x63*=r2,x64*=two,x65*=two,x66*=two;
+  }
+
+  [[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  void invMandelXform()
+  {
+                              x14/=r2,x15/=r2,x16/=r2;
+                              x24/=r2,x25/=r2,x26/=r2;
+                              x34/=r2,x35/=r2,x36/=r2;
+      x41/=r2,x42/=r2,x43/=r2,x44/=two,x45/=two,x46/=two;
+      x51/=r2,x52/=r2,x53/=r2,x54/=two,x55/=two,x56/=two;
+      x61/=r2,x62/=r2,x63/=r2,x64/=two,x65/=two,x66/=two;
+  }
+
+};
+
+/***************************************************************************** 
+ * Operator overloads for mandel6x6 tensors (4th order tensor)
+ *****************************************************************************/
+//mandel6x6 binary operators with scalars
+//multiplication by constant
+template <class A, class B>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+typename std::enable_if<is_scalar<B>, mandel6x6<decltype(A() * B())>>::type
+operator*(
+        mandel6x6<A> const& a, 
+        B const& c)
+{
+    return mandel6x6<decltype(a.x11()*c)>(
+            a.x11()*c, a.x12()*c, a.x13()*c, a.x14()*c, a.x15()*c, a.x16()*c,
+            a.x21()*c, a.x22()*c, a.x23()*c, a.x24()*c, a.x25()*c, a.x26()*c,
+            a.x31()*c, a.x32()*c, a.x33()*c, a.x34()*c, a.x35()*c, a.x36()*c,
+            a.x41()*c, a.x42()*c, a.x43()*c, a.x44()*c, a.x45()*c, a.x46()*c,
+            a.x51()*c, a.x52()*c, a.x53()*c, a.x54()*c, a.x55()*c, a.x56()*c,
+            a.x61()*c, a.x62()*c, a.x63()*c, a.x64()*c, a.x65()*c, a.x66()*c,
+            false);
+}
+
+//multiplication by constant
+template <class A, class B>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+typename std::enable_if<is_scalar<A>, mandel6x6<decltype(A() * B())>>::type 
+operator*(
+        A const& c, 
+        mandel6x6<B> const& t)
+{
+    return t * c;
+}
+
+//division by constant
+template <class A, class B>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+typename std::enable_if<is_scalar<B>, mandel6x6<decltype(A() * B())>>::type
+operator/(
+        mandel6x6<A> const& a, 
+        B const& c)
+{
+    return mandel6x6<decltype<(a.x11() / c)>(
+            a.x11()/c, a.x12()/c, a.x13()/c, a.x14()/c, a.x15()/c, a.x16()/c,
+            a.x21()/c, a.x22()/c, a.x23()/c, a.x24()/c, a.x25()/c, a.x26()/c,
+            a.x31()/c, a.x32()/c, a.x33()/c, a.x34()/c, a.x35()/c, a.x36()/c,
+            a.x41()/c, a.x42()/c, a.x43()/c, a.x44()/c, a.x45()/c, a.x46()/c,
+            a.x51()/c, a.x52()/c, a.x53()/c, a.x54()/c, a.x55()/c, a.x56()/c,
+            a.x61()/c, a.x62()/c, a.x63()/c, a.x64()/c, a.x65()/c, a.x66()/c,
+            false);
+}
+
+//division /= by constant
+template <class A>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator/=(
+        mandel6x6<A>& a, 
+        A const& c)
+{
+        a.x11()/=c; 
+        a.x12()/=c; 
+        a.x13()/=c; 
+        a.x14()/=c; 
+        a.x15()/=c;
+        a.x16()/=c;
+        a.x21()/=c;
+        a.x22()/=c;
+        a.x23()/=c;
+        a.x24()/=c;
+        a.x25()/=c;
+        a.x26()/=c;
+        a.x31()/=c;
+        a.x32()/=c;
+        a.x33()/=c;
+        a.x34()/=c;
+        a.x35()/=c;
+        a.x36()/=c;
+        a.x41()/=c;
+        a.x42()/=c;
+        a.x43()/=c;
+        a.x44()/=c;
+        a.x45()/=c;
+        a.x46()/=c;
+        a.x51()/=c;
+        a.x52()/=c;
+        a.x53()/=c;
+        a.x54()/=c;
+        a.x55()/=c;
+        a.x56()/=c;
+        a.x61()/=c;
+        a.x62()/=c;
+        a.x63()/=c;
+        a.x64()/=c;
+        a.x65()/=c;
+        a.x66()/=c;
+}
+
+//multiplication *= by constant
+template <class A>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator*=(
+        mandel6x6<A>& a, 
+        A const& c)
+{
+        a.x11()*=c; 
+        a.x12()*=c; 
+        a.x13()*=c; 
+        a.x14()*=c; 
+        a.x15()*=c;
+        a.x16()*=c;
+        a.x21()*=c;
+        a.x22()*=c;
+        a.x23()*=c;
+        a.x24()*=c;
+        a.x25()*=c;
+        a.x26()*=c;
+        a.x31()*=c;
+        a.x32()*=c;
+        a.x33()*=c;
+        a.x34()*=c;
+        a.x35()*=c;
+        a.x36()*=c;
+        a.x41()*=c;
+        a.x42()*=c;
+        a.x43()*=c;
+        a.x44()*=c;
+        a.x45()*=c;
+        a.x46()*=c;
+        a.x51()*=c;
+        a.x52()*=c;
+        a.x53()*=c;
+        a.x54()*=c;
+        a.x55()*=c;
+        a.x56()*=c;
+        a.x61()*=c;
+        a.x62()*=c;
+        a.x63()*=c;
+        a.x64()*=c;
+        a.x65()*=c;
+        a.x66()*=c;
+}
+
+//mandel6x6 += addition
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator+=(
+    mandel6x6<T>& a, 
+    mandel6x6<T> const& b)
+{
+    a.x11() += b.x11();
+    a.x12() += b.x12();
+    a.x13() += b.x13();
+    a.x14() += b.x14();
+    a.x15() += b.x15();
+    a.x16() += b.x16();
+    a.x21() += b.x21();
+    a.x22() += b.x22();
+    a.x23() += b.x23(); 
+    a.x24() += b.x24();
+    a.x25() += b.x25();
+    a.x26() += b.x26();
+    a.x31() += b.x31();
+    a.x32() += b.x32();
+    a.x33() += b.x33(); 
+    a.x34() += b.x34();
+    a.x35() += b.x35();
+    a.x36() += b.x36();
+    a.x41() += b.x41();
+    a.x42() += b.x42();
+    a.x43() += b.x43();
+    a.x44() += b.x44();
+    a.x45() += b.x45();
+    a.x46() += b.x46();
+    a.x51() += b.x51();
+    a.x52() += b.x52();
+    a.x53() += b.x53();
+    a.x54() += b.x54();
+    a.x55() += b.x55();
+    a.x56() += b.x56();
+    a.x61() += b.x61(); 
+    a.x62() += b.x62();
+    a.x63() += b.x63();
+    a.x64() += b.x64();
+    a.x65() += b.x65();
+    a.x66() += b.x66();
+}
+
+//mandel6x6 -= subtraction
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+void operator-=(
+    mandel6x6<T>& a, 
+    mandel6x6<T> const& b)
+{
+    a.x11() -= b.x11();
+    a.x12() -= b.x12();
+    a.x13() -= b.x13();
+    a.x14() -= b.x14();
+    a.x15() -= b.x15();
+    a.x16() -= b.x16();
+    a.x21() -= b.x21();
+    a.x22() -= b.x22();
+    a.x23() -= b.x23(); 
+    a.x24() -= b.x24();
+    a.x25() -= b.x25();
+    a.x26() -= b.x26();
+    a.x31() -= b.x31();
+    a.x32() -= b.x32();
+    a.x33() -= b.x33(); 
+    a.x34() -= b.x34();
+    a.x35() -= b.x35();
+    a.x36() -= b.x36();
+    a.x41() -= b.x41();
+    a.x42() -= b.x42();
+    a.x43() -= b.x43();
+    a.x44() -= b.x44();
+    a.x45() -= b.x45();
+    a.x46() -= b.x46();
+    a.x51() -= b.x51();
+    a.x52() -= b.x52();
+    a.x53() -= b.x53();
+    a.x54() -= b.x54();
+    a.x55() -= b.x55();
+    a.x56() -= b.x56();
+    a.x61() -= b.x61(); 
+    a.x62() -= b.x62();
+    a.x63() -= b.x63();
+    a.x64() -= b.x64();
+    a.x65() -= b.x65();
+    a.x66() -= b.x66();
+}
+//mandel6x6 addition
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator+(
+    mandel6x6<T> const& a, 
+    mandel6x6<U> const& b)
+{
+  return mandel6x6<decltype(a.x11()+b.x11())>(
+    a.x11() + b.x11(), a.x12() + b.x12(), a.x13() + b.x13(), a.x14() + b.x14(), a.x15() + b.x15(), a.x16() + b.x16(),
+    a.x21() + b.x21(), a.x22() + b.x22(), a.x23() + b.x23(), a.x24() + b.x24(), a.x25() + b.x25(), a.x26() + b.x26(),
+    a.x31() + b.x31(), a.x32() + b.x32(), a.x33() + b.x33(), a.x34() + b.x34(), a.x35() + b.x35(), a.x36() + b.x36(),
+    a.x41() + b.x41(), a.x42() + b.x42(), a.x43() + b.x43(), a.x44() + b.x44(), a.x45() + b.x45(), a.x46() + b.x46(),
+    a.x51() + b.x51(), a.x52() + b.x52(), a.x53() + b.x53(), a.x54() + b.x54(), a.x55() + b.x55(), a.x56() + b.x56(),
+    a.x61() + b.x61(), a.x62() + b.x62(), a.x63() + b.x63(), a.x64() + b.x64(), a.x65() + b.x65(), a.x66() + b.x66(),
+    false);
+}
+
+//mandel6x6 subtraction
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator-(
+    mandel6x6<T> const& a, 
+    mandel6x6<U> const& b)
+{
+  return mandel6x6<decltype(a.x11()-b.x11())>(
+    a.x11() - b.x11(), a.x12() - b.x12(), a.x13() - b.x13(), a.x14() - b.x14(), a.x15() - b.x15(), a.x16() - b.x16(),
+    a.x21() - b.x21(), a.x22() - b.x22(), a.x23() - b.x23(), a.x24() - b.x24(), a.x25() - b.x25(), a.x26() - b.x26(),
+    a.x31() - b.x31(), a.x32() - b.x32(), a.x33() - b.x33(), a.x34() - b.x34(), a.x35() - b.x35(), a.x36() - b.x36(),
+    a.x41() - b.x41(), a.x42() - b.x42(), a.x43() - b.x43(), a.x44() - b.x44(), a.x45() - b.x45(), a.x46() - b.x46(),
+    a.x51() - b.x51(), a.x52() - b.x52(), a.x53() - b.x53(), a.x54() - b.x54(), a.x55() - b.x55(), a.x56() - b.x56(),
+    a.x61() - b.x61(), a.x62() - b.x62(), a.x63() - b.x63(), a.x64() - b.x64(), a.x65() - b.x65(), a.x66() - b.x66(),
+    false);
+}
+
+//mandel6x1 negation
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+mandel6x6<T> operator-(
+    mandel6x6<T> const& a)
+{
+  return mandel6x6<T>(
+    -a.x11(), -a.x12(), -a.x13(), -a.x14(), -a.x15(), -a.x16(),
+    -a.x21(), -a.x22(), -a.x23(), -a.x24(), -a.x25(), -a.x26(),
+    -a.x31(), -a.x32(), -a.x33(), -a.x34(), -a.x35(), -a.x36(),
+    -a.x41(), -a.x42(), -a.x43(), -a.x44(), -a.x45(), -a.x46(),
+    -a.x51(), -a.x52(), -a.x53(), -a.x54(), -a.x55(), -a.x56(),
+    -a.x61(), -a.x62(), -a.x63(), -a.x64(), -a.x65(), -a.x66(),
+    false);
+}
+
+/***************************************************************************** 
+ * Linear Algebra for MandelVector (2nd order tensor)
+ *****************************************************************************/
+//trace
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+T trace(
+    mandel6x6<T> const& a)
+{
+  return a.x11() + a.x22() + a.x33() + a.x44() + a.x55() + a.x66();
+}
+
+//inverse
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+mandel6x6<T> Inverse(
+    mandel6x6<T> const &V)
+{
+    //partial pivoting in <dynamic_matrix.hpp>
+    //Direct calculation of inverse of (6x1) 2nd-order Mandel tensor 
+    mandel6x6<T> u;
+    T inv_det = 0.0;
+    T det = Det(V);
+
+    u.x1() = (V.x2()*V.x3()    - V.x4()*V.x4()/two)*inv_det;
+    u.x2() = (V.x1()*V.x3()    - V.x5()*V.x5()/two)*inv_det;
+    u.x3() = (V.x1()*V.x2()    - V.x6()*V.x6()/two)*inv_det;
+    u.x4() = (V.x6()*V.x5()/two - V.x1()*V.x4()/r2)*inv_det;
+    u.x5() = (V.x6()*V.x4()/two - V.x2()*V.x5()/r2)*inv_det;
+    u.x6() = (V.x4()*V.x5()/two - V.x6()*V.x3()/r2)*inv_det;
+    //not in mandel form anymore; return to mandel form for consistency with 
+    //other functions
+    u.MandelXform();
+    return u;
+}
+
+/** Create a 6x6 Mandel Tensor to Rotate a 6x6 Mandel Tensor
+ *
+ *	Convert 3x3 rotation operator to rotation operator for Mandel Vectors.
+ *	This Returns a tensor in Mandel Notation!
+ *
+ *  @param a Rotation Operator Tensor
+ *
+ *  @return Rotation Operator for Mandel as MandelTensor
+ */
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+mandel6x6<T> MandelTransformation(
+    matrix3x3<T> const& a)
+{
+    return mandel6x6<T>(
+        a.xx()*a.xx(),
+        a.xy()*a.xy(),
+        a.xz()*a.xz(),
+        a.xy()*a.xz()*r2,
+        a.xx()*a.xz()*r2,
+        a.xx()*a.xy()*r2,
+        a.yx()*a.yx(),
+        a.yy()*a.yy(),
+        a.yz()*a.yz(),
+        a.yy()*a.yz()*r2,
+        a.yx()*a.yz()*r2,
+        a.yx()*a.yy()*r2,
+        a.zx()*a.zx(),
+        a.zy()*a.zy(),
+        a.zz()*a.zz(),
+        a.zy()*a.zz()*r2,
+        a.zx()*a.zz()*r2,
+        a.zx()*a.zy()*r2,
+        a.yx()*a.zx()*r2,
+        a.yy()*a.zy()*r2,
+        a.yz()*a.zz()*r2,
+        a.yy()*a.zz()+a.yz()*a.zy(),
+        a.yz()*a.zx()+a.yx()*a.zz(),
+        a.yx()*a.zy()+a.yy()*a.zx(),
+        a.xx()*a.zx()*r2,
+        a.xy()*a.zy()*r2,
+        a.xz()*a.zz()*r2,
+        a.zy()*a.xz()+a.zz()*a.xy(),
+        a.zz()*a.xx()+a.zx()*a.xz(),
+        a.zx()*a.xy()+a.zy()*a.xx(),
+        a.xx()*a.yx()*r2,
+        a.xy()*a.yy()*r2,
+        a.xz()*a.yz()*r2,
+        a.xy()*a.yz()+a.xz()*a.yy(),
+        a.xz()*a.yx()+a.xx()*a.yz(),
+        a.xx()*a.yy()+a.xy()*a.yx(),
+        false); 
+}
+
+/** transpose **/
+template <class T>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+mandel6x6<T> transpose(
+    mandel6x6<T> const &d)
+{
+    return mandel6x6<T>(
+        d.x11(), d.x21(), d.x31(), d.x41(), d.x51(), d.x61(),
+        d.x12(), d.x22(), d.x32(), d.x42(), d.x52(), d.x62(),
+        d.x13(), d.x23(), d.x33(), d.x43(), d.x53(), d.x63(),
+        d.x14(), d.x24(), d.x34(), d.x44(), d.x54(), d.x64(),
+        d.x15(), d.x25(), d.x35(), d.x45(), d.x55(), d.x65(),
+        d.x16(), d.x26(), d.x36(), d.x46(), d.x56(), d.x66(),
+        false); //already transformed
+}
+
+/** Tensor multiply mandel6x6 (6x6) by mandel6x1 (6x1) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x6<T> const &C,
+    mandel6x1<U> const &v)
+{
+    return mandel6x1<decltype(C.x11*v.x1)>(
+        (C.x11()*v.x1() + C.x12()*v.x2() + C.x13()*v.x3() + C.x14()*v.x4() + C.x15()*v.x5() + C.x16()*v.x6()),
+        (C.x21()*v.x1() + C.x22()*v.x2() + C.x23()*v.x3() + C.x24()*v.x4() + C.x25()*v.x5() + C.x26()*v.x6()),
+        (C.x31()*v.x1() + C.x32()*v.x2() + C.x33()*v.x3() + C.x34()*v.x4() + C.x35()*v.x5() + C.x36()*v.x6()),
+        (C.x41()*v.x1() + C.x42()*v.x2() + C.x43()*v.x3() + C.x44()*v.x4() + C.x45()*v.x5() + C.x46()*v.x6()),
+        (C.x51()*v.x1() + C.x52()*v.x2() + C.x53()*v.x3() + C.x54()*v.x4() + C.x55()*v.x5() + C.x56()*v.x6()),
+        (C.x61()*v.x1() + C.x62()*v.x2() + C.x63()*v.x3() + C.x64()*v.x4() + C.x65()*v.x5() + C.x66()*v.x6()),
+        false); //already transformed
+}
+
+/** Tensor multiply Mandel6x6 (6x6) by symmetric3x3 (3x3) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x6<T> const &C, 
+    symmetric3x3<U> const &s)
+{
+    v = mandel6x1<T>(s);
+    return C*v;
+}
+
+/** Tensor multiply MandelVector (6x6) by diagonal3x3 (3x3) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    mandel6x6<T> const &v, 
+    diagonal3x3<U> const &t)
+{
+    return mandel6x1<decltype(t.xx() * v.xx())>(
+          t.xx()*v.x1(),
+          t.yy()*v.x2(),
+          t.zz()*v.x3(),
+          t.yy()*v.x4(),
+          t.xx()*v.x5(),
+          t.xx()*v.x6(),
+          false);
+}
+
+/** Tensor multiply diagonal3x3 (3x3) by MandelVector (6x1) **/
+template <class T, class U>
+[[nodiscard]] P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+auto operator*(
+    diagonal3x3<T> const &t, 
+    mandel6x1<U> const &v)
+{
+    return mandel6x1<decltype(tt.xx() * v.xx())>(
+          tt.xx()*vv.x1(),
+          tt.yy()*vv.x2(),
+          tt.zz()*vv.x3(),
+          tt.yy()*vv.x4(),
+          tt.xx()*vv.x5(),
+          tt.xx()*vv.x6(),
+          false);
+}
+
+//misc
+inline int constexpr mandel6x6_component_count = 36;
+

--- a/p3a_mandel6x6.hpp
+++ b/p3a_mandel6x6.hpp
@@ -41,13 +41,14 @@ class mandel6x6
    m_x61,m_x62,m_x63,m_x64,m_x65,m_x66;
  bool applyTransform;
 
- static constexpr T r2 = std::sqrt(T(2.0));
-
- static constexpr T r2i = T(1.0)/std::sqrt(T(2.0));
-
- static constexpr T two = T(2.0);
-
  public:
+
+  static constexpr T r2 = std::sqrt(T(2.0));
+
+  static constexpr T r2i = T(1.0)/std::sqrt(T(2.0));
+
+  static constexpr T two = T(2.0);
+
   /**** constructors, destructors, and assigns ****/
   P3A_ALWAYS_INLINE constexpr
   mandel6x6() = default;
@@ -68,8 +69,7 @@ class mandel6x6
       m_x61(X61),m_x62(X62),m_x63(X63),m_x64(X64),m_x65(X65),m_x66(X66),
        applyTransform(true)
   {
-    if (applyTransform)
-        this->MandelXform();
+    this->MandelXform();
   }
 
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
@@ -95,6 +95,20 @@ class mandel6x6
 
   P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
   mandel6x6(
+      static_matrix<T,6,6> const& X):
+    m_x11(X(0,0)),m_x12(X(0,1)),m_x13(X(0,2)),m_x14(X(0,3)),m_x15(X(0,4)),m_x16(X(0,5)),
+    m_x21(X(1,0)),m_x22(X(1,1)),m_x23(X(1,2)),m_x24(X(1,3)),m_x25(X(1,4)),m_x26(X(1,5)),
+    m_x31(X(2,0)),m_x32(X(2,1)),m_x33(X(2,2)),m_x34(X(2,3)),m_x35(X(2,4)),m_x36(X(2,5)),
+    m_x41(X(3,0)),m_x42(X(3,1)),m_x43(X(3,2)),m_x44(X(3,3)),m_x45(X(3,4)),m_x46(X(3,5)),
+    m_x51(X(4,0)),m_x52(X(4,1)),m_x53(X(4,2)),m_x54(X(4,3)),m_x55(X(4,4)),m_x56(X(4,5)),
+    m_x61(X(5,0)),m_x62(X(5,1)),m_x63(X(5,2)),m_x64(X(5,3)),m_x65(X(5,4)),m_x66(X(5,5)),
+    applyTransform(true)
+  {
+    this->MandelXform();
+  }
+
+  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
+  mandel6x6(
       static_matrix<T,6,6> const& X, bool const& Xform):
     m_x11(X(0,0)),m_x12(X(0,1)),m_x13(X(0,2)),m_x14(X(0,3)),m_x15(X(0,4)),m_x16(X(0,5)),
     m_x21(X(1,0)),m_x22(X(1,1)),m_x23(X(1,2)),m_x24(X(1,3)),m_x25(X(1,4)),m_x26(X(1,5)),
@@ -106,20 +120,6 @@ class mandel6x6
   {
     if (applyTransform)
         this->MandelXform();
-  }
-
-  P3A_HOST P3A_DEVICE P3A_ALWAYS_INLINE constexpr
-  mandel6x6(
-      static_matrix<T,6,6> const& X):
-    m_x11(X(0,0)),m_x12(X(0,1)),m_x13(X(0,2)),m_x14(X(0,3)),m_x15(X(0,4)),m_x16(X(0,5)),
-    m_x21(X(1,0)),m_x22(X(1,1)),m_x23(X(1,2)),m_x24(X(1,3)),m_x25(X(1,4)),m_x26(X(1,5)),
-    m_x31(X(2,0)),m_x32(X(2,1)),m_x33(X(2,2)),m_x34(X(2,3)),m_x35(X(2,4)),m_x36(X(2,5)),
-    m_x41(X(3,0)),m_x42(X(3,1)),m_x43(X(3,2)),m_x44(X(3,3)),m_x45(X(3,4)),m_x46(X(3,5)),
-    m_x51(X(4,0)),m_x52(X(4,1)),m_x53(X(4,2)),m_x54(X(4,3)),m_x55(X(4,4)),m_x56(X(4,5)),
-    m_x61(X(5,0)),m_x62(X(5,1)),m_x63(X(5,2)),m_x64(X(5,3)),m_x65(X(5,4)),m_x66(X(5,5)),
-    applyTransform(true)
-  {
-    this->MandelXform();
   }
 
   //return by mandel index 1-6,1-6
@@ -316,7 +316,6 @@ class mandel6x6
       m_x51/=r2,m_x52/=r2,m_x53/=r2,m_x54/=two,m_x55/=two,m_x56/=two;
       m_x61/=r2,m_x62/=r2,m_x63/=r2,m_x64/=two,m_x65/=two,m_x66/=two;
   }                        
-                             
 };
 
 /***************************************************************************** 
@@ -639,20 +638,9 @@ mandel6x6<U> inverse(
     U wmax =0;
     U fac =0; 
     U wcond = minimum_value<U>();
-    static_matrix<U,6,6> w;
-    static_matrix<U,6,6> ainv;
-    static_vector<U,6> dummy;
-
-     
-    dummy = dummy.zero();
-    ainv = ainv.identity();
-    w = w.zero();
-
-    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // Initialize and allocate
-    //
-    // Make working tensor from input Mandel Tensor
-    // while converting input 6x6 tensor T from Mandel form to normal form
+    static_matrix<U,6,6> w = static_matrix<U,6,6>::zero();
+    static_matrix<U,6,6> ainv = static_matrix<U,6,6>::identity();
+    static_vector<U,6> dummy = static_vector<U,6>::zero();
     
     // Row 1
     w(0,0)=T.x11();
@@ -949,5 +937,23 @@ auto operator*(
 
 //misc
 inline int constexpr mandel6x6_component_count = 36;
+
+                             
+//output print
+template <class U>
+P3A_ALWAYS_INLINE constexpr 
+std::ostream& operator<<(std::ostream& os, mandel6x6<U> const& a)
+{
+  os << std::cout.precision(4);
+  os << std::scientific;
+  os << "\t  | " << a.x11() << " " << a.x12() << " " << a.x13() << " " << a.x14()*a.r2i << " " << a.x15()*a.r2i << " " << a.x16()*a.r2i << " |" <<std::endl;
+  os << "\t  | " << a.x21() << " " << a.x22() << " " << a.x23() << " " << a.x24()*a.r2i << " " << a.x25()*a.r2i << " " << a.x26()*a.r2i << " |" <<std::endl;
+  os << "\t  | " << a.x31() << " " << a.x32() << " " << a.x33() << " " << a.x34()*a.r2i << " " << a.x35()*a.r2i << " " << a.x36()*a.r2i << " |" <<std::endl;
+  os << "\t  | " << a.x41()*a.r2i << " " << a.x42()*a.r2i << " " << a.x43()*a.r2i << " " << a.x44()/a.two << " " << a.x45()/a.two << " " << a.x46()/a.two << " |" <<std::endl;
+  os << "\t  | " << a.x51()*a.r2i << " " << a.x52()*a.r2i << " " << a.x53()*a.r2i << " " << a.x54()/a.two << " " << a.x55()/a.two << " " << a.x56()/a.two << " |" <<std::endl;
+  os << "\t  | " << a.x61()*a.r2i << " " << a.x62()*a.r2i << " " << a.x63()*a.r2i << " " << a.x64()/a.two << " " << a.x65()/a.two << " " << a.x66()/a.two << " |" <<std::endl;
+
+  return os;
+}
 
 }

--- a/p3a_static_matrix.hpp
+++ b/p3a_static_matrix.hpp
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "p3a_scalar.hpp"
 #include "p3a_static_array.hpp"
 
 namespace p3a {

--- a/p3a_unit_tests.cpp
+++ b/p3a_unit_tests.cpp
@@ -10,6 +10,9 @@
 #include "p3a_mandel6x6.hpp"
 #include "p3a_mandel3x6.hpp"
 #include "p3a_mandel6x3.hpp"
+
+using namespace p3a; 
+
 /*************************************************************************
  * This GoogleTest style file tests all aspects of the P3A library
  *
@@ -35,13 +38,13 @@
  *   Inverses
  */
 
-using Y double;
+using Y = double;
 
 Y abs_err = epsilon_value<Y>();
 
 struct TestData {
-  const Y r1 =  0.2946950525769927;
 
+  Y const r1 =  0.2946950525769927;
   vector3<Y> v;
   vector3<Y> vp;
   mandel6x1<Y> V;
@@ -82,15 +85,6 @@ struct TestData {
                TV(0.3458750937599743, 0.8168959802484831, 0.0040298826046717,
                   0.8168959802484831, 0.1560730533788416, 0.9667841040427785,
                   0.0040298826046717, 0.9667841040427785, 0.6018325296947370),
-               TVstatic(0,0)=0.3458750937599743,
-               TVstatic(0,1)=0.8168959802484831,
-               TVstatic(0,2)=0.0040298826046717,
-               TVstatic(1,0)=0.8168959802484831, 
-               TVstatic(1,1)=0.1560730533788416, 
-               TVstatic(1,2)=0.9667841040427785,
-               TVstatic(2,0)=0.0040298826046717, 
-               TVstatic(2,1)=0.9667841040427785,
-               TVstatic(2,2)=0.6018325296947370,
                C(0.4335153608215544, 0.0856007508096491, 0.6181864586228960, 1.0180326366236518, 0.9998149495390550, 1.3248978263217353,
                  0.4327952022077987, 0.3742135173559312, 0.1080020759711545, 0.8147725263605445, 0.9048931279343728, 1.2476465544083184,
                  0.1619267043337781, 0.8255468602509465, 0.4823784238849611, 0.6837503075397613, 0.0784973317433504, 0.8368479998334433,
@@ -98,12 +92,6 @@ struct TestData {
                  0.0836906759361557, 0.9338502039452401, 0.9911298229891556, 1.6059479559586896, 1.9166663623233735, 0.8109702524757447,
                  0.0501618784358511, 0.9139519661627958, 0.4597365381087316, 1.0569116390136390, 0.6655431451182421, 0.9678972164817718,
                  false),
-               Cstatic(0,0)=0.4335153608215544, Cstatic(0,1)=0.0856007508096491, Cstatic(0,2)=0.6181864586228960, Cstatic(0,3)=1.0180326366236518, Cstatic(0,4)=0.9998149495390550, Cstatic(0,5)=1.3248978263217353,
-               Cstatic(1,0)=0.4327952022077987, Cstatic(1,1)=0.3742135173559312, Cstatic(1,2)=0.1080020759711545, Cstatic(1,3)=0.8147725263605445, Cstatic(1,4)=0.9048931279343728, Cstatic(1,5)=1.2476465544083184,
-               Cstatic(2,0)=0.1619267043337781, Cstatic(2,1)=0.8255468602509465, Cstatic(2,2)=0.4823784238849611, Cstatic(2,3)=0.6837503075397613, Cstatic(2,4)=0.0784973317433504, Cstatic(2,5)=0.8368479998334433,
-               Cstatic(3,0)=0.0112200396694362, Cstatic(3,1)=0.8194354458300377, Cstatic(3,2)=1.1074040005476036, Cstatic(3,3)=0.6118023983888154, Cstatic(3,4)=0.4369542629777867, Cstatic(3,5)=0.6474343145633832,
-               Cstatic(4,0)=0.0836906759361557, Cstatic(4,1)=0.9338502039452401, Cstatic(4,2)=0.9911298229891556, Cstatic(4,3)=1.6059479559586896, Cstatic(4,4)=1.9166663623233735, Cstatic(4,5)=0.8109702524757447,
-               Cstatic(5,0)=0.0501618784358511, Cstatic(5,1)=0.9139519661627958, Cstatic(5,2)=0.4597365381087316, Cstatic(5,3)=1.0569116390136390, Cstatic(5,4)=0.6655431451182421, Cstatic(5,5)=0.9678972164817718,
                Ident(1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                      0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
                      0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
@@ -140,29 +128,76 @@ struct TestData {
                     0.1874635649351754, 0.2063901066888893, 0.2852170092848386,
                     0.7058726767702264, 0.4070564297078077, 0.3017792316742351,
                     false) {
-    VinvX = V;
-    VinvX.invMandelXform();
-    VpinvX = Vp;
-    VpinvX.invMandelXform();
+        VinvX = V;
+        VinvX.invMandelXform();
+        VpinvX = Vp;
+        VpinvX.invMandelXform();
 
-    CinvX = C;
-    CinvX.invMandelXform();
+        CinvX = C;
+        CinvX.invMandelXform();
 
-    CpinvX = Cp;
-    CpinvX.invMandelXform();
+        CpinvX = Cp;
+        CpinvX.invMandelXform();
 
-    e36invX = e36;
-    e36invX.invMandelXform();
+        e36invX = e36;
+        e36invX.invMandelXform();
 
-    e36pinvX = e36p;
-    e36pinvX.invMandelXform();
+        e36pinvX = e36p;
+        e36pinvX.invMandelXform();
 
-    e63invX = e63;
-    e63invX.invMandelXform();
+        e63invX = e63;
+        e63invX.invMandelXform();
 
-    e63pinvX = e63p;
-    e63pinvX.invMandelXform();
-  }
+        e63pinvX = e63p;
+        e63pinvX.invMandelXform();
+
+        TVstatic(0,0)=0.3458750937599743;
+        TVstatic(0,1)=0.8168959802484831;
+        TVstatic(0,2)=0.0040298826046717;
+        TVstatic(1,0)=0.8168959802484831; 
+        TVstatic(1,1)=0.1560730533788416; 
+        TVstatic(1,2)=0.9667841040427785;
+        TVstatic(2,0)=0.0040298826046717; 
+        TVstatic(2,1)=0.9667841040427785;
+        TVstatic(2,2)=0.6018325296947370;
+
+        Cstatic(0,0)=0.4335153608215544; 
+        Cstatic(0,1)=0.0856007508096491;
+        Cstatic(0,2)=0.6181864586228960, 
+        Cstatic(0,3)=1.0180326366236518, 
+        Cstatic(0,4)=0.9998149495390550, 
+        Cstatic(0,5)=1.3248978263217353,
+        Cstatic(1,0)=0.4327952022077987; 
+        Cstatic(1,1)=0.3742135173559312;
+        Cstatic(1,2)=0.1080020759711545;
+        Cstatic(1,3)=0.8147725263605445;
+        Cstatic(1,4)=0.9048931279343728;
+        Cstatic(1,5)=1.2476465544083184;
+        Cstatic(2,0)=0.1619267043337781; 
+        Cstatic(2,1)=0.8255468602509465; 
+        Cstatic(2,2)=0.4823784238849611; 
+        Cstatic(2,3)=0.6837503075397613; 
+        Cstatic(2,4)=0.0784973317433504; 
+        Cstatic(2,5)=0.8368479998334433;
+        Cstatic(3,0)=0.0112200396694362; 
+        Cstatic(3,1)=0.8194354458300377; 
+        Cstatic(3,2)=1.1074040005476036; 
+        Cstatic(3,3)=0.6118023983888154; 
+        Cstatic(3,4)=0.4369542629777867; 
+        Cstatic(3,5)=0.6474343145633832;
+        Cstatic(4,0)=0.0836906759361557; 
+        Cstatic(4,1)=0.9338502039452401; 
+        Cstatic(4,2)=0.9911298229891556; 
+        Cstatic(4,3)=1.6059479559586896; 
+        Cstatic(4,4)=1.9166663623233735; 
+        Cstatic(4,5)=0.8109702524757447;
+        Cstatic(5,0)=0.0501618784358511;
+        Cstatic(5,1)=0.9139519661627958; 
+        Cstatic(5,2)=0.4597365381087316;
+        Cstatic(5,3)=1.0569116390136390;
+        Cstatic(5,4)=0.6655431451182421;
+        Cstatic(5,5)=0.9678972164817718;
+    }
 };
 
 /**************************************************************************
@@ -174,9 +209,10 @@ TEST(mandel_tensors,LinAlg2ndOrderMandelVectorInverseV){
     TestData td;
     const auto & V = td.V;
     const auto & ident = td.ident;
-    mandel6x1 T = Inverse(V);
+    mandel6x1 T = inverse(V);
     //better comparison is to make sure it is identity tensor
-    mandel6x1 I;
+    mandel6x1 I = mandel6x1<Y>::identity();
+
     I = V*T;
 
     EXPECT_NEAR(ident.x1(),I.x1(),abs_err) << "I.x1";
@@ -191,14 +227,14 @@ TEST(mandel_tensors,LinAlg2ndOrderMandelVectorInverseV){
 TEST(mandel_tensors,LinAlg4thOrderMandelTensorInverseC){
 
     TestData td;
-    const auto & C =td.C;
+    const auto & C = td.C;
     const auto & Ident = td.Ident;
 
-    mandel6x6 Ct(C,true);
-    mandel6x6 St = Inverse(Ct);
-    mandel6x6 S;
+    mandel6x6 Ct = C;
+    Ct.MandelXform();
+    mandel6x6 St = inverse(Ct);
     St.invMandelXform();
-    S = C*St;
+    mandel6x6 S = C*St;
 
     EXPECT_NEAR(Ident.x11(),S.x11(),abs_err) << "S.x11()";
     EXPECT_NEAR(Ident.x12(),S.x12(),abs_err) << "S.x12()";
@@ -261,7 +297,7 @@ TEST(mandel_tensors,Construct2ndOrderVfromMatrix3x3Vxform){
     TestData td;
     const auto & V = td.V;
     const auto & TV = td.TV;
-    mandel6x1 Vt(TV);
+    mandel6x1 Vt= TV;
 
     EXPECT_FLOAT_EQ(V.x1(),Vt.x1()) << "V.x1";
     EXPECT_FLOAT_EQ(V.x2(),Vt.x2()) << "V.x2";
@@ -286,12 +322,12 @@ TEST(mandel_tensors,Construct2ndOrderVfromMatrix3x3V){
     EXPECT_FLOAT_EQ(VinvX.x6(),Vt.x6()) << "V.x6";
 }
 
-TEST(mandel_tensors,Construct2ndOrderVfromStaticMatrixVxform){
+TEST(mandel_tensors,Construct2ndOrderVconvertfromStaticMatrixVxform){
 
     TestData td;
     const auto & V = td.V;
     const auto & TV = td.TVstatic;
-    mandel6x1 Vt(TV);
+    mandel6x1<Y> Vt = TV;
 
     EXPECT_FLOAT_EQ(V.x1(),Vt.x1()) << "V.x1";
     EXPECT_FLOAT_EQ(V.x2(),Vt.x2()) << "V.x2";
@@ -428,8 +464,7 @@ TEST(mandel_tensors,Basics2ndOrderBinaryVmultReal){
     TestData td;
     const auto & V = td.V;
     const auto & r1 = td.r1;
-    mandel6x1 U;
-    U = V * r1;
+    mandel6x1 U = V * r1;
 
     EXPECT_FLOAT_EQ(V.x1()*r1,U.x1()) << "U.x1";
     EXPECT_FLOAT_EQ(V.x2()*r1,U.x2()) << "U.x2";
@@ -444,8 +479,7 @@ TEST(mandel_tensors,Basics2ndOrderBinaryRealmultV){
     TestData td;
     const auto & V = td.V;
     const auto & r1 = td.r1;
-    mandel6x1 U;
-    U = r1 * V;
+    mandel6x1 U = r1 * V;
 
     EXPECT_FLOAT_EQ(V.x1()*r1,U.x1()) << "U.x1";
     EXPECT_FLOAT_EQ(V.x2()*r1,U.x2()) << "U.x2";
@@ -460,8 +494,7 @@ TEST(mandel_tensors,Basics2ndOrderBinaryVdivReal){
     TestData td;
     const auto & V = td.V;
     const auto & r1 = td.r1;
-    mandel6x1 U;
-    U = V / r1;
+    mandel6x1 U = V / r1;
 
     EXPECT_FLOAT_EQ(V.x1()/r1,U.x1()) << "U.x1";
     EXPECT_FLOAT_EQ(V.x2()/r1,U.x2()) << "U.x2";
@@ -474,23 +507,6 @@ TEST(mandel_tensors,Basics2ndOrderBinaryVdivReal){
 /**************************************************************************
  * Linear Alegbra operation tests for mandel6x1 (2nd-order tensors)
  *************************************************************************/
-TEST(mandel_tensors,LinAlg2ndOrderTensorConversionV){
-
-    TestData td;
-    const auto & TV = td.TV;
-    matrix3x3 T(td.V);
-
-    EXPECT_FLOAT_EQ(TV.xx(),T.xx()) << "T.xx()";
-    EXPECT_FLOAT_EQ(TV.xy(),T.xy()) << "T.xy()";
-    EXPECT_FLOAT_EQ(TV.xz(),T.xz()) << "T.xz()";
-    EXPECT_FLOAT_EQ(TV.yx(),T.yx()) << "T.yx()";
-    EXPECT_FLOAT_EQ(TV.yy(),T.yy()) << "T.yy()";
-    EXPECT_FLOAT_EQ(TV.yz(),T.yz()) << "T.yz()";
-    EXPECT_FLOAT_EQ(TV.zx(),T.zx()) << "T.zx()";
-    EXPECT_FLOAT_EQ(TV.zy(),T.zy()) << "T.zy()";
-    EXPECT_FLOAT_EQ(TV.zz(),T.zz()) << "T.zz()";
-}
-
 TEST(mandel_tensors,LinAlg2ndOrderInverseMandelXformV){
 
     TestData td;
@@ -507,12 +523,12 @@ TEST(mandel_tensors,LinAlg2ndOrderInverseMandelXformV){
     EXPECT_FLOAT_EQ(VinvX.x6(),T.x6()) << "T.x6";
 }
 
-TEST(mandel_tensors,LinAlg2ndOrderDeterminateV){
+TEST(mandel_tensors,LinAlg2ndOrderDeterminantV){
 
     TestData td;
-    Real d = td.V.Det();
+    Y d = determinant(td.V);
 
-    EXPECT_FLOAT_EQ(-0.6860431470481314,d) << "Determinate of mandel6x1 V";
+    EXPECT_FLOAT_EQ(-0.6860431470481314,d) << "Determinant of mandel6x1 V";
 }
 
 TEST(mandel_tensors,LinAlg2ndOrderCxV){
@@ -585,7 +601,7 @@ TEST(mandel_tensors,TensorConvTestsMandelToTensor){
 
     TestData td;
     const auto & VinvX = td.VinvX;
-    matrix3x3 T = td.V;
+    matrix3x3 T = mandel6x1_to_matrix3x3(td.V);
 
     EXPECT_FLOAT_EQ(VinvX.x1(),T.xx()) << "T.xx()";
     EXPECT_FLOAT_EQ(VinvX.x6(),T.xy()) << "T.xy()";
@@ -670,7 +686,7 @@ TEST(mandel_tensors,symmetric3x3ConvTestsMandelVectorConstructor){
     TestData td;
     const auto & V = td.V;
     const auto & VinvX = td.VinvX;
-    symmetric3x3 U = V;
+    symmetric3x3 U = mandel6x1_to_symmetric3x3(V);
 
     EXPECT_FLOAT_EQ(VinvX.x1(),U.xx()) << "U.x1";
     EXPECT_FLOAT_EQ(VinvX.x2(),U.yy()) << "U.x2";
@@ -913,8 +929,7 @@ TEST(mandel_tensors,Basics4thOrderCaddCp){
     TestData td;
     const auto & C = td.C;
     const auto & Cp = td.Cp;
-    mandel6x6 W;
-    W = Cp + C;
+    mandel6x6 W = Cp + C;
 
     EXPECT_FLOAT_EQ(C.x11()+Cp.x11(),W.x11()) << "T.x11()";
     EXPECT_FLOAT_EQ(C.x12()+Cp.x12(),W.x12()) << "T.x12()";
@@ -959,8 +974,7 @@ TEST(mandel_tensors,Basics4thOrderCminusCp){
     TestData td;
     const auto & C = td.C;
     const auto & Cp = td.Cp;
-    mandel6x6 W;
-    W = C - Cp;
+    mandel6x6 W = C - Cp;
 
     EXPECT_FLOAT_EQ(C.x11()-Cp.x11(),W.x11()) << "T.x11()";
     EXPECT_FLOAT_EQ(C.x12()-Cp.x12(),W.x12()) << "T.x12()";
@@ -1051,8 +1065,7 @@ TEST(mandel_tensors,Basics4thOrderBinaryCxReal){
     TestData td;
     const auto & C = td.C;
     const auto & r1 = td.r1;
-    mandel6x6 W;
-    W = C*r1;
+    mandel6x6 W = C*r1;
 
     EXPECT_FLOAT_EQ(C.x11()*r1,W.x11()) << "T.x11()";
     EXPECT_FLOAT_EQ(C.x12()*r1,W.x12()) << "T.x12()";
@@ -1097,8 +1110,7 @@ TEST(mandel_tensors,Basics4thOrderBinaryRealxC){
     TestData td;
     const auto & C = td.C;
     const auto & r1 = td.r1;
-    mandel6x6 W;
-    W = r1 * C;
+    mandel6x6 W = r1 * C;
 
     EXPECT_FLOAT_EQ(C.x11()*r1,W.x11()) << "T.x11()";
     EXPECT_FLOAT_EQ(C.x12()*r1,W.x12()) << "T.x12()";
@@ -1189,8 +1201,7 @@ TEST(mandel_tensors,Basics4thOrderBinaryCdivReal){
     TestData td;
     const auto & C = td.C;
     const auto & r1 = td.r1;
-    mandel6x6 W;
-    W = C/r1;
+    mandel6x6 W = C/r1;
 
     EXPECT_FLOAT_EQ(C.x11()/r1,W.x11()) << "T.x11()";
     EXPECT_FLOAT_EQ(C.x12()/r1,W.x12()) << "T.x12()";
@@ -1237,7 +1248,7 @@ TEST(mandel_tensors,LinAlg4thOrderMembersTransposeC){
 
     TestData td;
     const auto & C = td.C;
-    mandel6x6 W = Transpose(C);
+    mandel6x6 W = transpose(C);
 
     EXPECT_FLOAT_EQ(C.x11(),W.x11()) << "T.x11()";
     EXPECT_FLOAT_EQ(C.x21(),W.x12()) << "T.x12()";
@@ -1508,8 +1519,7 @@ TEST(mandel_tensors,Basic3rdOrder36e36add36p){
     TestData td;
     const auto & e36p = td.e36p;
     const auto & e36 = td.e36;
-    mandel3x6 e;
-    e = e36 + e36p;
+    mandel3x6 e = e36 + e36p;
 
     EXPECT_FLOAT_EQ(e36.x11()+e36p.x11(),e.x11()) << "T.x11()";
     EXPECT_FLOAT_EQ(e36.x12()+e36p.x12(),e.x12()) << "T.x12()";
@@ -1536,8 +1546,7 @@ TEST(mandel_tensors,Basic3rdOrder36e36minus36p){
     TestData td;
     const auto & e36p = td.e36p;
     const auto & e36 = td.e36;
-    mandel3x6 e;
-    e = e36 - e36p;
+    mandel3x6 e = e36 - e36p;
 
     EXPECT_FLOAT_EQ(e36.x11()-e36p.x11(),e.x11()) << "T.x11()";
     EXPECT_FLOAT_EQ(e36.x12()-e36p.x12(),e.x12()) << "T.x12()";
@@ -1592,8 +1601,7 @@ TEST(mandel_tensors,Basic3rdOrder36Binarye36xreal){
     TestData td;
     const auto & e36 = td.e36;
     const auto & r1 = td.r1;
-    mandel3x6 e;
-    e = e36*r1;
+    mandel3x6 e = e36*r1;
 
     EXPECT_FLOAT_EQ(e36.x11()*r1,e.x11()) << "T.x11()";
     EXPECT_FLOAT_EQ(e36.x12()*r1,e.x12()) << "T.x12()";
@@ -1620,8 +1628,7 @@ TEST(mandel_tensors,Basic3rdOrder36Binaryrealxe36){
     TestData td;
     const auto & e36 = td.e36;
     const auto & r1 = td.r1;
-    mandel3x6 e;
-    e= r1 * e36;
+    mandel3x6 e= r1 * e36;
 
     EXPECT_FLOAT_EQ(e36.x11()*r1,e.x11()) << "T.x11()";
     EXPECT_FLOAT_EQ(e36.x12()*r1,e.x12()) << "T.x12()";
@@ -1674,8 +1681,7 @@ TEST(mandel_tensors,Basic3rdOrder36Binarye36divreal){
     TestData td;
     const auto & e36 = td.e36;
     const auto & r1 = td.r1;
-    mandel3x6 e;
-    e = e36 / r1;
+    mandel3x6 e = e36 / r1;
 
     EXPECT_FLOAT_EQ(e36.x11()/r1,e.x11()) << "T.x11()";
     EXPECT_FLOAT_EQ(e36.x12()/r1,e.x12()) << "T.x12()";
@@ -1732,7 +1738,7 @@ TEST(mandel_tensors,LinAlg3rdOrder36Transposee36){
 
     TestData td;
     const auto & e36 = td.e36;
-    mandel6x3 e = Transpose(e36);
+    mandel6x3 e = transpose(e36);
 
     EXPECT_FLOAT_EQ(e36.x11(),e.x11()) << "T.x11()";
     EXPECT_FLOAT_EQ(e36.x21(),e.x12()) << "T.x12()";
@@ -1974,8 +1980,7 @@ TEST(mandel_tensors,Basic3rdOrder63e63adde63p){
     TestData td;
     const auto & e63 = td.e63;
     const auto & e63p = td.e63p;
-    mandel6x3 f;
-    f = e63p + e63;
+    mandel6x3 f = e63p + e63;
 
     EXPECT_FLOAT_EQ(e63.x11()+e63p.x11(),f.x11()) << "e.x11()";
     EXPECT_FLOAT_EQ(e63.x12()+e63p.x12(),f.x12()) << "e.x12()";
@@ -2002,8 +2007,7 @@ TEST(mandel_tensors,Basic3rdOrder63e63minuse63p){
     TestData td;
     const auto & e63 = td.e63;
     const auto & e63p = td.e63p;
-    mandel6x3 f;
-    f = e63 - e63p;
+    mandel6x3 f = e63 - e63p;
 
     EXPECT_FLOAT_EQ(e63.x11()-e63p.x11(),f.x11()) << "e.x11()";
     EXPECT_FLOAT_EQ(e63.x12()-e63p.x12(),f.x12()) << "e.x12()";
@@ -2058,8 +2062,7 @@ TEST(mandel_tensors,Basic3rdOrderBinary63e63xReal){
     TestData td;
     const auto & e63 = td.e63;
     const auto & r1 = td.r1;
-    mandel6x3 f;
-    f= e63*r1;
+    mandel6x3 f = e63*r1;
 
     EXPECT_FLOAT_EQ(e63.x11()*r1,f.x11()) << "e.x11()";
     EXPECT_FLOAT_EQ(e63.x12()*r1,f.x12()) << "e.x12()";
@@ -2086,8 +2089,7 @@ TEST(mandel_tensors,Basic3rdOrder63BinaryRealxe63){
     TestData td;
     const auto & e63 = td.e63;
     const auto & r1 = td.r1;
-    mandel6x3 f;
-    f = r1*e63;
+    mandel6x3 f = r1*e63;
 
     EXPECT_FLOAT_EQ(e63.x11()*r1,f.x11()) << "e.x11()";
     EXPECT_FLOAT_EQ(e63.x12()*r1,f.x12()) << "e.x12()";
@@ -2142,8 +2144,7 @@ TEST(mandel_tensors,Basic3rdOrder63Binarye63divReal){
     TestData td;
     const auto & e63 = td.e63;
     const auto & r1 = td.r1;
-    mandel6x3 f;
-    f = e63/r1;
+    mandel6x3 f = e63/r1;
 
     EXPECT_FLOAT_EQ(e63.x11()/r1,f.x11()) << "e.x11()";
     EXPECT_FLOAT_EQ(e63.x12()/r1,f.x12()) << "e.x12()";
@@ -2200,7 +2201,7 @@ TEST(mandel_tensors,LinAlg3rdOrder63Transposee63){
 
     TestData td;
     const auto & e63 = td.e63;
-    mandel3x6 f = Transpose(e63);
+    mandel3x6 f = transpose(e63);
 
     EXPECT_FLOAT_EQ(e63.x11(),f.x11()) << "e.x11()";
     EXPECT_FLOAT_EQ(e63.x21(),f.x12()) << "e.x12()";

--- a/p3a_unit_tests.cpp
+++ b/p3a_unit_tests.cpp
@@ -1,7 +1,2298 @@
 #include "gtest/gtest.h"
+#include "p3a_macros.hpp"
+#include "p3a_constants.hpp"
+#include "p3a_static_matrix.hpp"
+#include "p3a_diagonal3x3.hpp"
+#include "p3a_vector3.hpp"
+#include "p3a_matrix3x3.hpp"
+#include "p3a_symmetric3x3.hpp"
+#include "p3a_mandel6x1.hpp"
+#include "p3a_mandel6x6.hpp"
+#include "p3a_mandel3x6.hpp"
+#include "p3a_mandel6x3.hpp"
+/*************************************************************************
+ * This GoogleTest style file tests all aspects of the P3A library
+ *
+ * Headers Tested
+ * ==============
+ *
+ * - `mandelNxN.hpp`
+ * 
+ *   Using randomly generated tensor data, computations will be compared 
+ *   against values computed with numpy (which uses blas/lapack). Individual
+ *   values for each tensor component will be compared for completeness.
+ * 
+ *   Aspects of the library tested inlcude:
+ *
+ *   - constructors from lists
+ *   - basic (+,-,*,/,-=,+=) member function operators ('self' operations)
+ *   - basic (+,-,*,/,+=,-=,*=,/=) operations with scalars 
+ *   - constructors taking other classes (including members of `static_matrix`, `matrix3x3`, `symmetric3x3`, and `diagonal3x3`)
+ *   - linear algebra operations within and between `mandelNxN` classes
+ *
+ * - `lie.hpp`
+ *
+ *   Inverses
+ */
 
-TEST(my_test_suite, two_plus_two)
-{
-  int sum = 2 + 2;
-  EXPECT_EQ(sum, 4);
+using Y double;
+
+Y abs_err = epsilon_value<Y>();
+
+struct TestData {
+  const Y r1 =  0.2946950525769927;
+
+  vector3<Y> v;
+  vector3<Y> vp;
+  mandel6x1<Y> V;
+  mandel6x1<Y> VinvX;
+  mandel6x1<Y> ident;
+  symmetric3x3<Y> Vsymm;
+  diagonal3x3<Y> Vdiag;
+  mandel6x1<Y> Vp;
+  mandel6x1<Y> VpinvX;
+  matrix3x3<Y> TV;
+  static_matrix<Y,3,3> TVstatic;
+  mandel6x6<Y> C;
+  static_matrix<Y,6,6> Cstatic;
+  mandel6x6<Y> CinvX;
+  mandel6x6<Y> Ident;
+  mandel6x6<Y> Cp;
+  mandel6x6<Y> CpinvX;
+  mandel3x6<Y> e36;
+  mandel3x6<Y> e36invX;
+  mandel3x6<Y> e36p;  
+  mandel3x6<Y> e36pinvX;
+  mandel6x3<Y> e63;
+  mandel6x3<Y> e63invX;
+  mandel6x3<Y> e63p;
+  mandel6x3<Y> e63pinvX;
+  
+  TestData() : v(0.5403153418505242, 0.1916615978226233, 0.7913471057605709), 
+               vp(0.2588658912519261, 0.9328687907855321, 0.2121274165250259), 
+               V(0.3458750937599743, 0.1560730533788416, 0.6018325296947370,
+                 1.3672391918240188, 0.0056991146342982, 1.1552653743154688,false),
+               ident(1.0, 1.0, 1.0, 0.0, 0.0, 0.0, false), 
+               Vsymm(0.3458750937599743, 0.8168959802484831, 0.0040298826046717,
+                                         0.1560730533788416, 0.9667841040427784,
+                                                             0.6018325296947370),
+               Vdiag(0.3458750937599743, 0.8168959802484831, 0.0040298826046717),
+               Vp(0.0332809212161841, 0.0487815715174135, 0.8094624540252358,
+                  0.4008775383705890, 0.6915662506016785, 0.1162162432201077,false),
+               TV(0.3458750937599743, 0.8168959802484831, 0.0040298826046717,
+                  0.8168959802484831, 0.1560730533788416, 0.9667841040427785,
+                  0.0040298826046717, 0.9667841040427785, 0.6018325296947370),
+               TVstatic(0,0)=0.3458750937599743,
+               TVstatic(0,1)=0.8168959802484831,
+               TVstatic(0,2)=0.0040298826046717,
+               TVstatic(1,0)=0.8168959802484831, 
+               TVstatic(1,1)=0.1560730533788416, 
+               TVstatic(1,2)=0.9667841040427785,
+               TVstatic(2,0)=0.0040298826046717, 
+               TVstatic(2,1)=0.9667841040427785,
+               TVstatic(2,2)=0.6018325296947370,
+               C(0.4335153608215544, 0.0856007508096491, 0.6181864586228960, 1.0180326366236518, 0.9998149495390550, 1.3248978263217353,
+                 0.4327952022077987, 0.3742135173559312, 0.1080020759711545, 0.8147725263605445, 0.9048931279343728, 1.2476465544083184,
+                 0.1619267043337781, 0.8255468602509465, 0.4823784238849611, 0.6837503075397613, 0.0784973317433504, 0.8368479998334433,
+                 0.0112200396694362, 0.8194354458300377, 1.1074040005476036, 0.6118023983888154, 0.4369542629777867, 0.6474343145633832,
+                 0.0836906759361557, 0.9338502039452401, 0.9911298229891556, 1.6059479559586896, 1.9166663623233735, 0.8109702524757447,
+                 0.0501618784358511, 0.9139519661627958, 0.4597365381087316, 1.0569116390136390, 0.6655431451182421, 0.9678972164817718,
+                 false),
+               Cstatic(0,0)=0.4335153608215544, Cstatic(0,1)=0.0856007508096491, Cstatic(0,2)=0.6181864586228960, Cstatic(0,3)=1.0180326366236518, Cstatic(0,4)=0.9998149495390550, Cstatic(0,5)=1.3248978263217353,
+               Cstatic(1,0)=0.4327952022077987, Cstatic(1,1)=0.3742135173559312, Cstatic(1,2)=0.1080020759711545, Cstatic(1,3)=0.8147725263605445, Cstatic(1,4)=0.9048931279343728, Cstatic(1,5)=1.2476465544083184,
+               Cstatic(2,0)=0.1619267043337781, Cstatic(2,1)=0.8255468602509465, Cstatic(2,2)=0.4823784238849611, Cstatic(2,3)=0.6837503075397613, Cstatic(2,4)=0.0784973317433504, Cstatic(2,5)=0.8368479998334433,
+               Cstatic(3,0)=0.0112200396694362, Cstatic(3,1)=0.8194354458300377, Cstatic(3,2)=1.1074040005476036, Cstatic(3,3)=0.6118023983888154, Cstatic(3,4)=0.4369542629777867, Cstatic(3,5)=0.6474343145633832,
+               Cstatic(4,0)=0.0836906759361557, Cstatic(4,1)=0.9338502039452401, Cstatic(4,2)=0.9911298229891556, Cstatic(4,3)=1.6059479559586896, Cstatic(4,4)=1.9166663623233735, Cstatic(4,5)=0.8109702524757447,
+               Cstatic(5,0)=0.0501618784358511, Cstatic(5,1)=0.9139519661627958, Cstatic(5,2)=0.4597365381087316, Cstatic(5,3)=1.0569116390136390, Cstatic(5,4)=0.6655431451182421, Cstatic(5,5)=0.9678972164817718,
+               Ident(1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                     0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+                     0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+                     0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+                     0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+                     0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+                     false),
+               Cp(0.2107177965118975, 0.1575416472166756, 0.5687654031408809, 0.0187036991768127, 0.3377232536213498, 1.2061579849914903,
+                  0.9690547680956271, 0.3015620428716760, 0.0117926801846069, 0.9799577916244374, 1.3212262938876842, 1.1437745297112247,
+                  0.9477962697578962, 0.8362711354333037, 0.5573723018243313, 1.1469535452828015, 1.3018482448421571, 1.2345256143574863,
+                  1.1283311601253478, 0.8511773708296858, 0.5606130265475940, 1.7722378395723914, 0.5637212302658510, 1.2310906790509168,
+                  0.7107977300479361, 0.1201771916290927, 0.8985377565988617, 1.6007054847018209, 1.8945186334241886, 1.6472528162998632,
+                  0.6135597538445192, 1.1831257314989769, 1.2978577062887620, 0.0659440885591793, 1.6164910199618434, 1.8004733085589755,
+                  false),
+               e36(0.8076127837790422, 0.0119054861420681, 0.3198164644230427, 0.1899714025547371, 0.0810795183410036, 0.3999599660633990,
+                   0.0453167988352610, 0.2818248347311008, 0.1508671814551668, 0.2127405166893033, 0.6128683635764686, 0.4153444264017785,
+                   0.5405046604793561, 0.4391783723249735, 0.4128631387354691, 0.5546654249524924, 0.6862523687819362, 0.6488819206134113,
+                   false),
+               e36p(0.1350855076155520, 0.0231767044698068, 0.9464219592050042, 0.1065057861528435, 0.2688248383393013, 0.1909939208122375,
+                    0.6097426473273645, 0.7344489953830811, 0.8160894918005591, 0.3734452187287570, 0.2222233196071084, 0.5049930480412529,
+                    0.2163593876325339, 0.0370067441280660, 0.3742486996899349, 0.3756620371052928, 0.2105298764336539, 0.3698923292958400,
+                    false),
+               e63(0.4759634421237341, 0.8867644229624673, 0.4135404273124733,
+                   0.8568504365470173, 0.1472947329145138, 0.4477610978101461,
+                   0.7307484706668289, 0.2502091219941188, 0.0617040225205491,
+                   0.4119163419942556, 0.1499018857533562, 0.3357608808746134,
+                   0.3481855982554204, 0.5219168123093268, 0.6767633687457478,
+                   0.1958577356414437, 0.3181944873075155, 0.2417581438483243,
+                   false),
+               e63p(0.5608766530609716, 0.1521742176592169, 0.0109210634329266,
+                    0.2873082726699938, 0.5245336001209888, 0.6563889052851136,
+                    0.8040961321642845, 0.2438452443118183, 0.9532018807957614,
+                    0.4882124674604895, 0.5228073932512954, 0.4459480468559615,
+                    0.1874635649351754, 0.2063901066888893, 0.2852170092848386,
+                    0.7058726767702264, 0.4070564297078077, 0.3017792316742351,
+                    false) {
+    VinvX = V;
+    VinvX.invMandelXform();
+    VpinvX = Vp;
+    VpinvX.invMandelXform();
+
+    CinvX = C;
+    CinvX.invMandelXform();
+
+    CpinvX = Cp;
+    CpinvX.invMandelXform();
+
+    e36invX = e36;
+    e36invX.invMandelXform();
+
+    e36pinvX = e36p;
+    e36pinvX.invMandelXform();
+
+    e63invX = e63;
+    e63invX.invMandelXform();
+
+    e63pinvX = e63p;
+    e63pinvX.invMandelXform();
+  }
+};
+
+/**************************************************************************
+ * Test Mandel Inverses:
+ *   Many tests rely on the inverse being correct
+ *************************************************************************/
+TEST(mandel_tensors,LinAlg2ndOrderMandelVectorInverseV){
+
+    TestData td;
+    const auto & V = td.V;
+    const auto & ident = td.ident;
+    mandel6x1 T = Inverse(V);
+    //better comparison is to make sure it is identity tensor
+    mandel6x1 I;
+    I = V*T;
+
+    EXPECT_NEAR(ident.x1(),I.x1(),abs_err) << "I.x1";
+    EXPECT_NEAR(ident.x2(),I.x2(),abs_err) << "I.x2";
+    EXPECT_NEAR(ident.x3(),I.x3(),abs_err) << "I.x3";
+    EXPECT_NEAR(ident.x4(),I.x4(),abs_err) << "I.x4";
+    EXPECT_NEAR(ident.x5(),I.x5(),abs_err) << "I.x5";
+    EXPECT_NEAR(ident.x6(),I.x6(),abs_err) << "I.x6";
+
+}
+
+TEST(mandel_tensors,LinAlg4thOrderMandelTensorInverseC){
+
+    TestData td;
+    const auto & C =td.C;
+    const auto & Ident = td.Ident;
+
+    mandel6x6 Ct(C,true);
+    mandel6x6 St = Inverse(Ct);
+    mandel6x6 S;
+    St.invMandelXform();
+    S = C*St;
+
+    EXPECT_NEAR(Ident.x11(),S.x11(),abs_err) << "S.x11()";
+    EXPECT_NEAR(Ident.x12(),S.x12(),abs_err) << "S.x12()";
+    EXPECT_NEAR(Ident.x13(),S.x13(),abs_err) << "S.x13()";
+    EXPECT_NEAR(Ident.x14(),S.x14(),abs_err) << "S.x14()";
+    EXPECT_NEAR(Ident.x15(),S.x15(),abs_err) << "S.x15()";
+    EXPECT_NEAR(Ident.x16(),S.x16(),abs_err) << "S.x16()";
+    EXPECT_NEAR(Ident.x21(),S.x21(),abs_err) << "S.x21()";
+    EXPECT_NEAR(Ident.x22(),S.x22(),abs_err) << "S.x22()";
+    EXPECT_NEAR(Ident.x23(),S.x23(),abs_err) << "S.x23()";
+    EXPECT_NEAR(Ident.x24(),S.x24(),abs_err) << "S.x24()";
+    EXPECT_NEAR(Ident.x25(),S.x25(),abs_err) << "S.x25()";
+    EXPECT_NEAR(Ident.x26(),S.x26(),abs_err) << "S.x26()";
+    EXPECT_NEAR(Ident.x31(),S.x31(),abs_err) << "S.x31()";
+    EXPECT_NEAR(Ident.x32(),S.x32(),abs_err) << "S.x32()";
+    EXPECT_NEAR(Ident.x33(),S.x33(),abs_err) << "S.x33()";
+    EXPECT_NEAR(Ident.x34(),S.x34(),abs_err) << "S.x34()";
+    EXPECT_NEAR(Ident.x35(),S.x35(),abs_err) << "S.x35()";
+    EXPECT_NEAR(Ident.x36(),S.x36(),abs_err) << "S.x36()";
+    EXPECT_NEAR(Ident.x41(),S.x41(),abs_err) << "S.x41()";
+    EXPECT_NEAR(Ident.x42(),S.x42(),abs_err) << "S.x42()";
+    EXPECT_NEAR(Ident.x43(),S.x43(),abs_err) << "S.x43()";
+    EXPECT_NEAR(Ident.x44(),S.x44(),abs_err) << "S.x44()";
+    EXPECT_NEAR(Ident.x45(),S.x45(),abs_err) << "S.x45()";
+    EXPECT_NEAR(Ident.x46(),S.x46(),abs_err) << "S.x46()";
+    EXPECT_NEAR(Ident.x51(),S.x51(),abs_err) << "S.x51()";
+    EXPECT_NEAR(Ident.x52(),S.x52(),abs_err) << "S.x52()";
+    EXPECT_NEAR(Ident.x53(),S.x53(),abs_err) << "S.x53()";
+    EXPECT_NEAR(Ident.x54(),S.x54(),abs_err) << "S.x54()";
+    EXPECT_NEAR(Ident.x55(),S.x55(),abs_err) << "S.x55()";
+    EXPECT_NEAR(Ident.x56(),S.x56(),abs_err) << "S.x56()";
+    EXPECT_NEAR(Ident.x61(),S.x61(),abs_err) << "S.x61()";
+    EXPECT_NEAR(Ident.x62(),S.x62(),abs_err) << "S.x62()";
+    EXPECT_NEAR(Ident.x63(),S.x63(),abs_err) << "S.x63()";
+    EXPECT_NEAR(Ident.x64(),S.x64(),abs_err) << "S.x64()";
+    EXPECT_NEAR(Ident.x65(),S.x65(),abs_err) << "S.x65()";
+    EXPECT_NEAR(Ident.x66(),S.x66(),abs_err) << "S.x66()";
+}
+
+/**************************************************************************
+ * Constructor tests for mandel6x1 (2nd-order tensors)
+ *************************************************************************/
+TEST(mandel_tensors,Construct2ndOrderVfromListxform){
+
+    TestData td;
+    const auto & V = td.V;
+
+    mandel6x1 Vt = V; //V made from list initially
+
+    EXPECT_FLOAT_EQ(V.x1(),Vt.x1()) << "V.x1";
+    EXPECT_FLOAT_EQ(V.x2(),Vt.x2()) << "V.x2";
+    EXPECT_FLOAT_EQ(V.x3(),Vt.x3()) << "V.x3";
+    EXPECT_FLOAT_EQ(V.x4(),Vt.x4()) << "V.x4";
+    EXPECT_FLOAT_EQ(V.x5(),Vt.x5()) << "V.x5";
+    EXPECT_FLOAT_EQ(V.x6(),Vt.x6()) << "V.x6";
+}
+
+TEST(mandel_tensors,Construct2ndOrderVfromMatrix3x3Vxform){
+
+    TestData td;
+    const auto & V = td.V;
+    const auto & TV = td.TV;
+    mandel6x1 Vt(TV);
+
+    EXPECT_FLOAT_EQ(V.x1(),Vt.x1()) << "V.x1";
+    EXPECT_FLOAT_EQ(V.x2(),Vt.x2()) << "V.x2";
+    EXPECT_FLOAT_EQ(V.x3(),Vt.x3()) << "V.x3";
+    EXPECT_FLOAT_EQ(V.x4(),Vt.x4()) << "V.x4";
+    EXPECT_FLOAT_EQ(V.x5(),Vt.x5()) << "V.x5";
+    EXPECT_FLOAT_EQ(V.x6(),Vt.x6()) << "V.x6";
+}
+
+TEST(mandel_tensors,Construct2ndOrderVfromMatrix3x3V){
+
+    TestData td;
+    const auto & VinvX = td.VinvX;
+    mandel6x1 Vt(td.TV);
+    Vt.invMandelXform();
+
+    EXPECT_FLOAT_EQ(VinvX.x1(),Vt.x1()) << "V.x1";
+    EXPECT_FLOAT_EQ(VinvX.x2(),Vt.x2()) << "V.x2";
+    EXPECT_FLOAT_EQ(VinvX.x3(),Vt.x3()) << "V.x3";
+    EXPECT_FLOAT_EQ(VinvX.x4(),Vt.x4()) << "V.x4";
+    EXPECT_FLOAT_EQ(VinvX.x5(),Vt.x5()) << "V.x5";
+    EXPECT_FLOAT_EQ(VinvX.x6(),Vt.x6()) << "V.x6";
+}
+
+TEST(mandel_tensors,Construct2ndOrderVfromStaticMatrixVxform){
+
+    TestData td;
+    const auto & V = td.V;
+    const auto & TV = td.TVstatic;
+    mandel6x1 Vt(TV);
+
+    EXPECT_FLOAT_EQ(V.x1(),Vt.x1()) << "V.x1";
+    EXPECT_FLOAT_EQ(V.x2(),Vt.x2()) << "V.x2";
+    EXPECT_FLOAT_EQ(V.x3(),Vt.x3()) << "V.x3";
+    EXPECT_FLOAT_EQ(V.x4(),Vt.x4()) << "V.x4";
+    EXPECT_FLOAT_EQ(V.x5(),Vt.x5()) << "V.x5";
+    EXPECT_FLOAT_EQ(V.x6(),Vt.x6()) << "V.x6";
+}
+
+TEST(mandel_tensors,Construct2ndOrderVfromStaticMatrixVxform){
+
+    TestData td;
+    const auto & V = td.V;
+    const auto & TV = td.TVstatic;
+    mandel6x1 Vt(TV);
+
+    EXPECT_FLOAT_EQ(V.x1(),Vt.x1()) << "V.x1";
+    EXPECT_FLOAT_EQ(V.x2(),Vt.x2()) << "V.x2";
+    EXPECT_FLOAT_EQ(V.x3(),Vt.x3()) << "V.x3";
+    EXPECT_FLOAT_EQ(V.x4(),Vt.x4()) << "V.x4";
+    EXPECT_FLOAT_EQ(V.x5(),Vt.x5()) << "V.x5";
+    EXPECT_FLOAT_EQ(V.x6(),Vt.x6()) << "V.x6";
+}
+
+TEST(mandel_tensors,Construct2ndOrderVfromsymmetric3x3Vxform){
+
+    TestData td;
+    const auto & V = td.V;
+    mandel6x1 Vt(td.Vsymm);    
+
+    EXPECT_FLOAT_EQ(V.x1(),Vt.x1()) << "V.x1";
+    EXPECT_FLOAT_EQ(V.x2(),Vt.x2()) << "V.x2";
+    EXPECT_FLOAT_EQ(V.x3(),Vt.x3()) << "V.x3";
+    EXPECT_FLOAT_EQ(V.x4(),Vt.x4()) << "V.x4";
+    EXPECT_FLOAT_EQ(V.x5(),Vt.x5()) << "V.x5";
+    EXPECT_FLOAT_EQ(V.x6(),Vt.x6()) << "V.x6";
+}
+
+TEST(mandel_tensors,Construct2ndOrderVfromsymmetric3x3V){
+
+    TestData td;
+    const auto & VinvX = td.VinvX;
+    mandel6x1 Vt(td.Vsymm,false);    
+
+    EXPECT_FLOAT_EQ(VinvX.x1(),Vt.x1()) << "V.x1";
+    EXPECT_FLOAT_EQ(VinvX.x2(),Vt.x2()) << "V.x2";
+    EXPECT_FLOAT_EQ(VinvX.x3(),Vt.x3()) << "V.x3";
+    EXPECT_FLOAT_EQ(VinvX.x4(),Vt.x4()) << "V.x4";
+    EXPECT_FLOAT_EQ(VinvX.x5(),Vt.x5()) << "V.x5";
+    EXPECT_FLOAT_EQ(VinvX.x6(),Vt.x6()) << "V.x6";
+}
+
+/**************************************************************************
+ * Basic operation tests for mandel6x1 (2nd-order tensors)
+ *************************************************************************/
+TEST(mandel_tensors,Basics2ndOrderVplusVp){
+
+    TestData td;
+    mandel6x1 Us = td.V + td.Vp;
+    mandel6x1 U = Us-td.V-td.Vp;
+
+    EXPECT_NEAR(0.,U.x1(),abs_err) << "U.x1";
+    EXPECT_NEAR(0.,U.x2(),abs_err) << "U.x2";
+    EXPECT_NEAR(0.,U.x3(),abs_err) << "U.x3";
+    EXPECT_NEAR(0.,U.x4(),abs_err) << "U.x4";
+    EXPECT_NEAR(0.,U.x5(),abs_err) << "U.x5";
+    EXPECT_NEAR(0.,U.x6(),abs_err) << "U.x6";
+}
+
+TEST(mandel_tensors,Basics2ndOrderVplusequalVp){
+
+    TestData td;
+    mandel6x1 Us = td.V;
+    Us += td.Vp;
+    mandel6x1 U = Us-td.V-td.Vp;
+
+    EXPECT_NEAR(0.,U.x1(),abs_err) << "U.x1";
+    EXPECT_NEAR(0.,U.x2(),abs_err) << "U.x2";
+    EXPECT_NEAR(0.,U.x3(),abs_err) << "U.x3";
+    EXPECT_NEAR(0.,U.x4(),abs_err) << "U.x4";
+    EXPECT_NEAR(0.,U.x5(),abs_err) << "U.x5";
+    EXPECT_NEAR(0.,U.x6(),abs_err) << "U.x6";
+}
+
+TEST(mandel_tensors,Basics2ndOrderVxReal){
+
+    TestData td;
+    const auto & V = td.V;
+    const auto & r1 = td.r1;
+    mandel6x1 U = td.V; 
+    U*=r1;
+
+    EXPECT_FLOAT_EQ(V.x1()*r1,U.x1()) << "U.x1";
+    EXPECT_FLOAT_EQ(V.x2()*r1,U.x2()) << "U.x2";
+    EXPECT_FLOAT_EQ(V.x3()*r1,U.x3()) << "U.x3";
+    EXPECT_FLOAT_EQ(V.x4()*r1,U.x4()) << "U.x4";
+    EXPECT_FLOAT_EQ(V.x5()*r1,U.x5()) << "U.x5";
+    EXPECT_FLOAT_EQ(V.x6()*r1,U.x6()) << "U.x6";
+}
+
+TEST(mandel_tensors,Basics2ndOrderVdivReal){
+
+    TestData td;
+    const auto & V = td.V;
+    const auto & r1 = td.r1;
+    mandel6x1 U = V;
+    U /= r1;
+
+    EXPECT_FLOAT_EQ(V.x1()/r1,U.x1()) << "U.x1";
+    EXPECT_FLOAT_EQ(V.x2()/r1,U.x2()) << "U.x2";
+    EXPECT_FLOAT_EQ(V.x3()/r1,U.x3()) << "U.x3";
+    EXPECT_FLOAT_EQ(V.x4()/r1,U.x4()) << "U.x4";
+    EXPECT_FLOAT_EQ(V.x5()/r1,U.x5()) << "U.x5";
+    EXPECT_FLOAT_EQ(V.x6()/r1,U.x6()) << "U.x6";
+}
+
+TEST(mandel_tensors,Basics2ndOrderVminusVp){
+
+    TestData td;
+    const auto & V = td.V;
+    const auto & Vp = td.Vp;
+    mandel6x1 U = td.V - td.Vp;
+
+    EXPECT_FLOAT_EQ(0.,V.x1()-Vp.x1()-U.x1()) << "U.x1";
+    EXPECT_FLOAT_EQ(0.,V.x2()-Vp.x2()-U.x2()) << "U.x2";
+    EXPECT_FLOAT_EQ(0.,V.x3()-Vp.x3()-U.x3()) << "U.x3";
+    EXPECT_FLOAT_EQ(0.,V.x4()-Vp.x4()-U.x4()) << "U.x4";
+    EXPECT_FLOAT_EQ(0.,V.x5()-Vp.x5()-U.x5()) << "U.x5";
+    EXPECT_FLOAT_EQ(0.,V.x6()-Vp.x6()-U.x6()) << "U.x6";
+}
+
+TEST(mandel_tensors,Basics2ndOrderBinaryVmultReal){
+
+    TestData td;
+    const auto & V = td.V;
+    const auto & r1 = td.r1;
+    mandel6x1 U;
+    U = V * r1;
+
+    EXPECT_FLOAT_EQ(V.x1()*r1,U.x1()) << "U.x1";
+    EXPECT_FLOAT_EQ(V.x2()*r1,U.x2()) << "U.x2";
+    EXPECT_FLOAT_EQ(V.x3()*r1,U.x3()) << "U.x3";
+    EXPECT_FLOAT_EQ(V.x4()*r1,U.x4()) << "U.x4";
+    EXPECT_FLOAT_EQ(V.x5()*r1,U.x5()) << "U.x5";
+    EXPECT_FLOAT_EQ(V.x6()*r1,U.x6()) << "U.x6";
+}
+
+TEST(mandel_tensors,Basics2ndOrderBinaryRealmultV){
+
+    TestData td;
+    const auto & V = td.V;
+    const auto & r1 = td.r1;
+    mandel6x1 U;
+    U = r1 * V;
+
+    EXPECT_FLOAT_EQ(V.x1()*r1,U.x1()) << "U.x1";
+    EXPECT_FLOAT_EQ(V.x2()*r1,U.x2()) << "U.x2";
+    EXPECT_FLOAT_EQ(V.x3()*r1,U.x3()) << "U.x3";
+    EXPECT_FLOAT_EQ(V.x4()*r1,U.x4()) << "U.x4";
+    EXPECT_FLOAT_EQ(V.x5()*r1,U.x5()) << "U.x5";
+    EXPECT_FLOAT_EQ(V.x6()*r1,U.x6()) << "U.x6";
+}
+
+TEST(mandel_tensors,Basics2ndOrderBinaryVdivReal){
+
+    TestData td;
+    const auto & V = td.V;
+    const auto & r1 = td.r1;
+    mandel6x1 U;
+    U = V / r1;
+
+    EXPECT_FLOAT_EQ(V.x1()/r1,U.x1()) << "U.x1";
+    EXPECT_FLOAT_EQ(V.x2()/r1,U.x2()) << "U.x2";
+    EXPECT_FLOAT_EQ(V.x3()/r1,U.x3()) << "U.x3";
+    EXPECT_FLOAT_EQ(V.x4()/r1,U.x4()) << "U.x4";
+    EXPECT_FLOAT_EQ(V.x5()/r1,U.x5()) << "U.x5";
+    EXPECT_FLOAT_EQ(V.x6()/r1,U.x6()) << "U.x6";
+}
+
+/**************************************************************************
+ * Linear Alegbra operation tests for mandel6x1 (2nd-order tensors)
+ *************************************************************************/
+TEST(mandel_tensors,LinAlg2ndOrderTensorConversionV){
+
+    TestData td;
+    const auto & TV = td.TV;
+    matrix3x3 T(td.V);
+
+    EXPECT_FLOAT_EQ(TV.xx(),T.xx()) << "T.xx()";
+    EXPECT_FLOAT_EQ(TV.xy(),T.xy()) << "T.xy()";
+    EXPECT_FLOAT_EQ(TV.xz(),T.xz()) << "T.xz()";
+    EXPECT_FLOAT_EQ(TV.yx(),T.yx()) << "T.yx()";
+    EXPECT_FLOAT_EQ(TV.yy(),T.yy()) << "T.yy()";
+    EXPECT_FLOAT_EQ(TV.yz(),T.yz()) << "T.yz()";
+    EXPECT_FLOAT_EQ(TV.zx(),T.zx()) << "T.zx()";
+    EXPECT_FLOAT_EQ(TV.zy(),T.zy()) << "T.zy()";
+    EXPECT_FLOAT_EQ(TV.zz(),T.zz()) << "T.zz()";
+}
+
+TEST(mandel_tensors,LinAlg2ndOrderInverseMandelXformV){
+
+    TestData td;
+    const auto & V = td.V;
+    const auto & VinvX = td.VinvX;
+    mandel6x1 T = V;
+    T.invMandelXform();
+
+    EXPECT_FLOAT_EQ(VinvX.x1(),T.x1()) << "T.x1";
+    EXPECT_FLOAT_EQ(VinvX.x2(),T.x2()) << "T.x2";
+    EXPECT_FLOAT_EQ(VinvX.x3(),T.x3()) << "T.x3";
+    EXPECT_FLOAT_EQ(VinvX.x4(),T.x4()) << "T.x4";
+    EXPECT_FLOAT_EQ(VinvX.x5(),T.x5()) << "T.x5";
+    EXPECT_FLOAT_EQ(VinvX.x6(),T.x6()) << "T.x6";
+}
+
+TEST(mandel_tensors,LinAlg2ndOrderDeterminateV){
+
+    TestData td;
+    Real d = td.V.Det();
+
+    EXPECT_FLOAT_EQ(-0.6860431470481314,d) << "Determinate of mandel6x1 V";
+}
+
+TEST(mandel_tensors,LinAlg2ndOrderCxV){
+
+    TestData td;
+    const auto & ident = td.ident;
+    mandel6x1 T = td.C * td.V;
+
+    EXPECT_FLOAT_EQ(3.4635476194506110,T.x1()) << "T.x1";
+    EXPECT_FLOAT_EQ(2.8336057738272911,T.x2()) << "T.x2";
+    EXPECT_FLOAT_EQ(2.3772421613021302,T.x3()) << "T.x3";
+    EXPECT_FLOAT_EQ(2.3851731903163613,T.x4()) << "T.x4";
+    EXPECT_FLOAT_EQ(3.9147136807559804,T.x5()) << "T.x5";
+    EXPECT_FLOAT_EQ(3.0036995840611000,T.x6()) << "T.x6";
+}
+
+TEST(mandel_tensors,LinAlg2ndOrderCxTensorV){
+
+    TestData td;
+    mandel6x1 T = td.C*td.TV;
+
+    EXPECT_FLOAT_EQ(3.4635476194506110,T.x1()) << "T.x1";
+    EXPECT_FLOAT_EQ(2.8336057738272911,T.x2()) << "T.x2";
+    EXPECT_FLOAT_EQ(2.3772421613021302,T.x3()) << "T.x3";
+    EXPECT_FLOAT_EQ(2.3851731903163613,T.x4()) << "T.x4";
+    EXPECT_FLOAT_EQ(3.9147136807559804,T.x5()) << "T.x5";
+    EXPECT_FLOAT_EQ(3.0036995840611000,T.x6()) << "T.x6";
+}
+
+TEST(mandel_tensors,LinAlg2ndOrdere63xVectorv){
+
+    TestData td;
+    mandel6x1 T = td.e63*td.v;
+
+    EXPECT_FLOAT_EQ(0.7543830564053962,T.x1()) << "T.x1";
+    EXPECT_FLOAT_EQ(0.8455346292231598,T.x2()) << "T.x2";
+    EXPECT_FLOAT_EQ(0.4916193894817055,T.x3()) << "T.x3";
+    EXPECT_FLOAT_EQ(0.5169985553863012,T.x4()) << "T.x4";
+    EXPECT_FLOAT_EQ(0.8237161638682240,T.x5()) << "T.x5";
+    EXPECT_FLOAT_EQ(0.3581252106713043,T.x6()) << "T.x6";
+}
+
+/**************************************************************************
+ * physlib::vector3 Conversion tests
+ *************************************************************************/
+TEST(mandel_tensors,VectorConvTestse36xV){
+
+    TestData td;
+    vector3 T = td.e36*td.V;
+
+    EXPECT_FLOAT_EQ(1.1959255529807966,T.x()) << "T.x";
+    EXPECT_FLOAT_EQ(0.9246490053867547,T.y()) << "T.y";
+    EXPECT_FLOAT_EQ(2.0158676300370968,T.z()) << "T.z";
+}
+
+TEST(mandel_tensors,VectorConvTestsTensorxVector3){
+
+    TestData td;
+    vector3 T = td.TV*td.v;
+
+    EXPECT_FLOAT_EQ(0.3466382442875668,T.x()) << "T.x";
+    EXPECT_FLOAT_EQ(1.2363564442415020,T.y()) << "T.y";
+    EXPECT_FLOAT_EQ(0.6637312240540059,T.z()) << "T.z";
+}
+
+/**************************************************************************
+ * Tensor Conversion tests
+ *************************************************************************/
+TEST(mandel_tensors,TensorConvTestsMandelToTensor){
+
+    TestData td;
+    const auto & VinvX = td.VinvX;
+    matrix3x3 T = td.V;
+
+    EXPECT_FLOAT_EQ(VinvX.x1(),T.xx()) << "T.xx()";
+    EXPECT_FLOAT_EQ(VinvX.x6(),T.xy()) << "T.xy()";
+    EXPECT_FLOAT_EQ(VinvX.x5(),T.xz()) << "T.xz()";
+    EXPECT_FLOAT_EQ(VinvX.x6(),T.yx()) << "T.yx()";
+    EXPECT_FLOAT_EQ(VinvX.x2(),T.yy()) << "T.yy()";
+    EXPECT_FLOAT_EQ(VinvX.x4(),T.yz()) << "T.yz()";
+    EXPECT_FLOAT_EQ(VinvX.x5(),T.zx()) << "T.zx()";
+    EXPECT_FLOAT_EQ(VinvX.x4(),T.zy()) << "T.zy()";
+    EXPECT_FLOAT_EQ(VinvX.x3(),T.zz()) << "T.zz()";
+}
+
+TEST(mandel_tensors,TensorConvTestse36xe63){
+
+    TestData td;
+    matrix3x3 T = td.e36*td.e63;
+
+    EXPECT_FLOAT_EQ(0.8131190728640454,T.xx()) << "T.xx()";
+    EXPECT_FLOAT_EQ(0.9959957879323522,T.xy()) << "T.xy()";
+    EXPECT_FLOAT_EQ(0.5743955040157696,T.xz()) << "T.xz()";
+    EXPECT_FLOAT_EQ(0.7556684864696379,T.yx()) << "T.yx()";
+    EXPECT_FLOAT_EQ(0.6033617978655575,T.yy()) << "T.yy()";
+    EXPECT_FLOAT_EQ(0.7408493369039156,T.yz()) << "T.yz()";
+    EXPECT_FLOAT_EQ(1.5297772340856588,T.zx()) << "T.zx()";
+    EXPECT_FLOAT_EQ(1.2950737798283347,T.zy()) << "T.zy()";
+    EXPECT_FLOAT_EQ(1.2531807400797446,T.zz()) << "T.zz()";
+}
+
+TEST(mandel_tensors,TensorConvTestsVxTensor){
+
+    TestData td;
+    matrix3x3 T = td.V*td.TV;
+
+    EXPECT_FLOAT_EQ(0.7869648629834085,T.xx()) << "T.xx()";
+    EXPECT_FLOAT_EQ(0.4139354501342279,T.xy()) << "T.xy()";
+    EXPECT_FLOAT_EQ(0.7935811988267519,T.xz()) << "T.xz()";
+    EXPECT_FLOAT_EQ(0.4139354501342279,T.yx()) << "T.yx()";
+    EXPECT_FLOAT_EQ(1.6263493443669228,T.yy()) << "T.yy()";
+    EXPECT_FLOAT_EQ(0.7360230649814389,T.yz()) << "T.yz()";
+    EXPECT_FLOAT_EQ(0.7935811988267519,T.zx()) << "T.zx()";
+    EXPECT_FLOAT_EQ(0.7360230649814389,T.zy()) << "T.zy()";
+    EXPECT_FLOAT_EQ(1.2968901375823718,T.zz()) << "T.zz()";
+}
+
+TEST(mandel_tensors,TensorConvTestsTensorxV){
+
+    TestData td;
+    matrix3x3 T = td.TV*td.V;
+
+    EXPECT_FLOAT_EQ(0.7869648629834085,T.xx()) << "T.xx()";
+    EXPECT_FLOAT_EQ(0.4139354501342279,T.xy()) << "T.xy()";
+    EXPECT_FLOAT_EQ(0.7935811988267519,T.xz()) << "T.xz()";
+    EXPECT_FLOAT_EQ(0.4139354501342279,T.yx()) << "T.yx()";
+    EXPECT_FLOAT_EQ(1.6263493443669228,T.yy()) << "T.yy()";
+    EXPECT_FLOAT_EQ(0.7360230649814389,T.yz()) << "T.yz()";
+    EXPECT_FLOAT_EQ(0.7935811988267519,T.zx()) << "T.zx()";
+    EXPECT_FLOAT_EQ(0.7360230649814389,T.zy()) << "T.zy()";
+    EXPECT_FLOAT_EQ(1.2968901375823718,T.zz()) << "T.zz()";
+}
+
+TEST(mandel_tensors,TensorConvTestsTensorxTensor){
+
+    TestData td;
+    matrix3x3 T = td.TV*td.TV;
+
+    EXPECT_FLOAT_EQ(0.7869648629834085,T.xx()) << "T.xx()";
+    EXPECT_FLOAT_EQ(0.4139354501342279,T.xy()) << "T.xy()";
+    EXPECT_FLOAT_EQ(0.7935811988267519,T.xz()) << "T.xz()";
+    EXPECT_FLOAT_EQ(0.4139354501342279,T.yx()) << "T.yx()";
+    EXPECT_FLOAT_EQ(1.6263493443669228,T.yy()) << "T.yy()";
+    EXPECT_FLOAT_EQ(0.7360230649814389,T.yz()) << "T.yz()";
+    EXPECT_FLOAT_EQ(0.7935811988267519,T.zx()) << "T.zx()";
+    EXPECT_FLOAT_EQ(0.7360230649814389,T.zy()) << "T.zy()";
+    EXPECT_FLOAT_EQ(1.2968901375823718,T.zz()) << "T.zz()";
+}
+
+/**************************************************************************
+ * symmetric3x3 Conversion tests
+ *************************************************************************/
+TEST(mandel_tensors,symmetric3x3ConvTestsMandelVectorConstructor){
+
+    TestData td;
+    const auto & V = td.V;
+    const auto & VinvX = td.VinvX;
+    symmetric3x3 U = V;
+
+    EXPECT_FLOAT_EQ(VinvX.x1(),U.xx()) << "U.x1";
+    EXPECT_FLOAT_EQ(VinvX.x2(),U.yy()) << "U.x2";
+    EXPECT_FLOAT_EQ(VinvX.x3(),U.zz()) << "U.x3";
+    EXPECT_FLOAT_EQ(VinvX.x4(),U.yz()) << "U.x4";
+    EXPECT_FLOAT_EQ(VinvX.x5(),U.xz()) << "U.x5";
+    EXPECT_FLOAT_EQ(VinvX.x6(),U.xy()) << "U.x6";
+}
+
+/**************************************************************************
+ * Constructor tests for 4th-order MandelTensors:
+ *************************************************************************/
+TEST(mandel_tensors,Construct4thOrderCfromListxform){
+
+    //already done, made from initial setup  
+    TestData td;
+    const auto &C = td.C;
+
+    EXPECT_FLOAT_EQ(0.4335153608215544,C.x11()) << "C.x11()";
+    EXPECT_FLOAT_EQ(0.0856007508096491,C.x12()) << "C.x12()";
+    EXPECT_FLOAT_EQ(0.6181864586228960,C.x13()) << "C.x13()";
+    EXPECT_FLOAT_EQ(1.0180326366236518,C.x14()) << "C.x14()";
+    EXPECT_FLOAT_EQ(0.9998149495390550,C.x15()) << "C.x15()";
+    EXPECT_FLOAT_EQ(1.3248978263217353,C.x16()) << "C.x16()";
+    EXPECT_FLOAT_EQ(0.4327952022077987,C.x21()) << "C.x21()";
+    EXPECT_FLOAT_EQ(0.3742135173559312,C.x22()) << "C.x22()";
+    EXPECT_FLOAT_EQ(0.1080020759711545,C.x23()) << "C.x23()";
+    EXPECT_FLOAT_EQ(0.8147725263605445,C.x24()) << "C.x24()";
+    EXPECT_FLOAT_EQ(0.9048931279343728,C.x25()) << "C.x25()";
+    EXPECT_FLOAT_EQ(1.2476465544083184,C.x26()) << "C.x26()";
+    EXPECT_FLOAT_EQ(0.1619267043337781,C.x31()) << "C.x31()";
+    EXPECT_FLOAT_EQ(0.8255468602509465,C.x32()) << "C.x32()";
+    EXPECT_FLOAT_EQ(0.4823784238849611,C.x33()) << "C.x33()";
+    EXPECT_FLOAT_EQ(0.6837503075397613,C.x34()) << "C.x34()";
+    EXPECT_FLOAT_EQ(0.0784973317433504,C.x35()) << "C.x35()";
+    EXPECT_FLOAT_EQ(0.8368479998334433,C.x36()) << "C.x36()";
+    EXPECT_FLOAT_EQ(0.0112200396694362,C.x41()) << "C.x41()";
+    EXPECT_FLOAT_EQ(0.8194354458300377,C.x42()) << "C.x42()";
+    EXPECT_FLOAT_EQ(1.1074040005476036,C.x43()) << "C.x43()";
+    EXPECT_FLOAT_EQ(0.6118023983888154,C.x44()) << "C.x44()";
+    EXPECT_FLOAT_EQ(0.4369542629777867,C.x45()) << "C.x45()";
+    EXPECT_FLOAT_EQ(0.6474343145633832,C.x46()) << "C.x46()";
+    EXPECT_FLOAT_EQ(0.0836906759361557,C.x51()) << "C.x51()";
+    EXPECT_FLOAT_EQ(0.9338502039452401,C.x52()) << "C.x52()";
+    EXPECT_FLOAT_EQ(0.9911298229891556,C.x53()) << "C.x53()";
+    EXPECT_FLOAT_EQ(1.6059479559586896,C.x54()) << "C.x54()";
+    EXPECT_FLOAT_EQ(1.9166663623233735,C.x55()) << "C.x55()";
+    EXPECT_FLOAT_EQ(0.8109702524757447,C.x56()) << "C.x56()";
+    EXPECT_FLOAT_EQ(0.0501618784358511,C.x61()) << "C.x61()";
+    EXPECT_FLOAT_EQ(0.9139519661627958,C.x62()) << "C.x62()";
+    EXPECT_FLOAT_EQ(0.4597365381087316,C.x63()) << "C.x63()";
+    EXPECT_FLOAT_EQ(1.0569116390136390,C.x64()) << "C.x64()";
+    EXPECT_FLOAT_EQ(0.6655431451182421,C.x65()) << "C.x65()";
+    EXPECT_FLOAT_EQ(0.9678972164817718,C.x66()) << "C.x66()";
+}
+
+TEST(mandel_tensors,Construct4thOrderCfromC){
+
+    //already done, made from initial setup  
+    TestData td;
+    const auto &C(td.C);
+
+    EXPECT_FLOAT_EQ(0.4335153608215544,C.x11()) << "C.x11()";
+    EXPECT_FLOAT_EQ(0.0856007508096491,C.x12()) << "C.x12()";
+    EXPECT_FLOAT_EQ(0.6181864586228960,C.x13()) << "C.x13()";
+    EXPECT_FLOAT_EQ(1.0180326366236518,C.x14()) << "C.x14()";
+    EXPECT_FLOAT_EQ(0.9998149495390550,C.x15()) << "C.x15()";
+    EXPECT_FLOAT_EQ(1.3248978263217353,C.x16()) << "C.x16()";
+    EXPECT_FLOAT_EQ(0.4327952022077987,C.x21()) << "C.x21()";
+    EXPECT_FLOAT_EQ(0.3742135173559312,C.x22()) << "C.x22()";
+    EXPECT_FLOAT_EQ(0.1080020759711545,C.x23()) << "C.x23()";
+    EXPECT_FLOAT_EQ(0.8147725263605445,C.x24()) << "C.x24()";
+    EXPECT_FLOAT_EQ(0.9048931279343728,C.x25()) << "C.x25()";
+    EXPECT_FLOAT_EQ(1.2476465544083184,C.x26()) << "C.x26()";
+    EXPECT_FLOAT_EQ(0.1619267043337781,C.x31()) << "C.x31()";
+    EXPECT_FLOAT_EQ(0.8255468602509465,C.x32()) << "C.x32()";
+    EXPECT_FLOAT_EQ(0.4823784238849611,C.x33()) << "C.x33()";
+    EXPECT_FLOAT_EQ(0.6837503075397613,C.x34()) << "C.x34()";
+    EXPECT_FLOAT_EQ(0.0784973317433504,C.x35()) << "C.x35()";
+    EXPECT_FLOAT_EQ(0.8368479998334433,C.x36()) << "C.x36()";
+    EXPECT_FLOAT_EQ(0.0112200396694362,C.x41()) << "C.x41()";
+    EXPECT_FLOAT_EQ(0.8194354458300377,C.x42()) << "C.x42()";
+    EXPECT_FLOAT_EQ(1.1074040005476036,C.x43()) << "C.x43()";
+    EXPECT_FLOAT_EQ(0.6118023983888154,C.x44()) << "C.x44()";
+    EXPECT_FLOAT_EQ(0.4369542629777867,C.x45()) << "C.x45()";
+    EXPECT_FLOAT_EQ(0.6474343145633832,C.x46()) << "C.x46()";
+    EXPECT_FLOAT_EQ(0.0836906759361557,C.x51()) << "C.x51()";
+    EXPECT_FLOAT_EQ(0.9338502039452401,C.x52()) << "C.x52()";
+    EXPECT_FLOAT_EQ(0.9911298229891556,C.x53()) << "C.x53()";
+    EXPECT_FLOAT_EQ(1.6059479559586896,C.x54()) << "C.x54()";
+    EXPECT_FLOAT_EQ(1.9166663623233735,C.x55()) << "C.x55()";
+    EXPECT_FLOAT_EQ(0.8109702524757447,C.x56()) << "C.x56()";
+    EXPECT_FLOAT_EQ(0.0501618784358511,C.x61()) << "C.x61()";
+    EXPECT_FLOAT_EQ(0.9139519661627958,C.x62()) << "C.x62()";
+    EXPECT_FLOAT_EQ(0.4597365381087316,C.x63()) << "C.x63()";
+    EXPECT_FLOAT_EQ(1.0569116390136390,C.x64()) << "C.x64()";
+    EXPECT_FLOAT_EQ(0.6655431451182421,C.x65()) << "C.x65()";
+    EXPECT_FLOAT_EQ(0.9678972164817718,C.x66()) << "C.x66()";
+}
+
+TEST(mandel_tensors,Construct4thOrderCfromstaticmatrixxform){
+
+    TestData td;
+    const mandel6x6 C(td.Cstatic);
+
+    EXPECT_FLOAT_EQ(0.4335153608215544,C.x11()) << "C.x11()";
+    EXPECT_FLOAT_EQ(0.0856007508096491,C.x12()) << "C.x12()";
+    EXPECT_FLOAT_EQ(0.6181864586228960,C.x13()) << "C.x13()";
+    EXPECT_FLOAT_EQ(1.0180326366236518,C.x14()) << "C.x14()";
+    EXPECT_FLOAT_EQ(0.9998149495390550,C.x15()) << "C.x15()";
+    EXPECT_FLOAT_EQ(1.3248978263217353,C.x16()) << "C.x16()";
+    EXPECT_FLOAT_EQ(0.4327952022077987,C.x21()) << "C.x21()";
+    EXPECT_FLOAT_EQ(0.3742135173559312,C.x22()) << "C.x22()";
+    EXPECT_FLOAT_EQ(0.1080020759711545,C.x23()) << "C.x23()";
+    EXPECT_FLOAT_EQ(0.8147725263605445,C.x24()) << "C.x24()";
+    EXPECT_FLOAT_EQ(0.9048931279343728,C.x25()) << "C.x25()";
+    EXPECT_FLOAT_EQ(1.2476465544083184,C.x26()) << "C.x26()";
+    EXPECT_FLOAT_EQ(0.1619267043337781,C.x31()) << "C.x31()";
+    EXPECT_FLOAT_EQ(0.8255468602509465,C.x32()) << "C.x32()";
+    EXPECT_FLOAT_EQ(0.4823784238849611,C.x33()) << "C.x33()";
+    EXPECT_FLOAT_EQ(0.6837503075397613,C.x34()) << "C.x34()";
+    EXPECT_FLOAT_EQ(0.0784973317433504,C.x35()) << "C.x35()";
+    EXPECT_FLOAT_EQ(0.8368479998334433,C.x36()) << "C.x36()";
+    EXPECT_FLOAT_EQ(0.0112200396694362,C.x41()) << "C.x41()";
+    EXPECT_FLOAT_EQ(0.8194354458300377,C.x42()) << "C.x42()";
+    EXPECT_FLOAT_EQ(1.1074040005476036,C.x43()) << "C.x43()";
+    EXPECT_FLOAT_EQ(0.6118023983888154,C.x44()) << "C.x44()";
+    EXPECT_FLOAT_EQ(0.4369542629777867,C.x45()) << "C.x45()";
+    EXPECT_FLOAT_EQ(0.6474343145633832,C.x46()) << "C.x46()";
+    EXPECT_FLOAT_EQ(0.0836906759361557,C.x51()) << "C.x51()";
+    EXPECT_FLOAT_EQ(0.9338502039452401,C.x52()) << "C.x52()";
+    EXPECT_FLOAT_EQ(0.9911298229891556,C.x53()) << "C.x53()";
+    EXPECT_FLOAT_EQ(1.6059479559586896,C.x54()) << "C.x54()";
+    EXPECT_FLOAT_EQ(1.9166663623233735,C.x55()) << "C.x55()";
+    EXPECT_FLOAT_EQ(0.8109702524757447,C.x56()) << "C.x56()";
+    EXPECT_FLOAT_EQ(0.0501618784358511,C.x61()) << "C.x61()";
+    EXPECT_FLOAT_EQ(0.9139519661627958,C.x62()) << "C.x62()";
+    EXPECT_FLOAT_EQ(0.4597365381087316,C.x63()) << "C.x63()";
+    EXPECT_FLOAT_EQ(1.0569116390136390,C.x64()) << "C.x64()";
+    EXPECT_FLOAT_EQ(0.6655431451182421,C.x65()) << "C.x65()";
+    EXPECT_FLOAT_EQ(0.9678972164817718,C.x66()) << "C.x66()";
+}
+
+/**************************************************************************
+ * Basic Operations 4th-order MandelTensors
+ *************************************************************************/
+TEST(mandel_tensors,Basics4thOrderCpluseqCp){
+
+    TestData td;
+    const auto & C = td.C;
+    const auto & Cp = td.Cp;
+    mandel6x6 W = C;
+    W += Cp;
+
+    EXPECT_FLOAT_EQ(C.x11()+Cp.x11(),W.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(C.x12()+Cp.x12(),W.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(C.x13()+Cp.x13(),W.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(C.x14()+Cp.x14(),W.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(C.x15()+Cp.x15(),W.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(C.x16()+Cp.x16(),W.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(C.x21()+Cp.x21(),W.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(C.x22()+Cp.x22(),W.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(C.x23()+Cp.x23(),W.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(C.x24()+Cp.x24(),W.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(C.x25()+Cp.x25(),W.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(C.x26()+Cp.x26(),W.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(C.x31()+Cp.x31(),W.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(C.x32()+Cp.x32(),W.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(C.x33()+Cp.x33(),W.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(C.x34()+Cp.x34(),W.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(C.x35()+Cp.x35(),W.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(C.x36()+Cp.x36(),W.x36()) << "T.x36()";
+    EXPECT_FLOAT_EQ(C.x41()+Cp.x41(),W.x41()) << "T.x41()";
+    EXPECT_FLOAT_EQ(C.x42()+Cp.x42(),W.x42()) << "T.x42()";
+    EXPECT_FLOAT_EQ(C.x43()+Cp.x43(),W.x43()) << "T.x43()";
+    EXPECT_FLOAT_EQ(C.x44()+Cp.x44(),W.x44()) << "T.x44()";
+    EXPECT_FLOAT_EQ(C.x45()+Cp.x45(),W.x45()) << "T.x45()";
+    EXPECT_FLOAT_EQ(C.x46()+Cp.x46(),W.x46()) << "T.x46()";
+    EXPECT_FLOAT_EQ(C.x51()+Cp.x51(),W.x51()) << "T.x51()";
+    EXPECT_FLOAT_EQ(C.x52()+Cp.x52(),W.x52()) << "T.x52()";
+    EXPECT_FLOAT_EQ(C.x53()+Cp.x53(),W.x53()) << "T.x53()";
+    EXPECT_FLOAT_EQ(C.x54()+Cp.x54(),W.x54()) << "T.x54()";
+    EXPECT_FLOAT_EQ(C.x55()+Cp.x55(),W.x55()) << "T.x55()";
+    EXPECT_FLOAT_EQ(C.x56()+Cp.x56(),W.x56()) << "T.x56()";
+    EXPECT_FLOAT_EQ(C.x61()+Cp.x61(),W.x61()) << "T.x61()";
+    EXPECT_FLOAT_EQ(C.x62()+Cp.x62(),W.x62()) << "T.x62()";
+    EXPECT_FLOAT_EQ(C.x63()+Cp.x63(),W.x63()) << "T.x63()";
+    EXPECT_FLOAT_EQ(C.x64()+Cp.x64(),W.x64()) << "T.x64()";
+    EXPECT_FLOAT_EQ(C.x65()+Cp.x65(),W.x65()) << "T.x65()";
+    EXPECT_FLOAT_EQ(C.x66()+Cp.x66(),W.x66()) << "T.x66()";
+}
+
+TEST(mandel_tensors,Basics4thOrderCminuseqCp){
+
+    TestData td;
+    const auto & C = td.C;
+    const auto & Cp = td.Cp;
+    mandel6x6 W = C;
+    W -= Cp;
+    EXPECT_FLOAT_EQ(C.x11()-Cp.x11(),W.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(C.x12()-Cp.x12(),W.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(C.x13()-Cp.x13(),W.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(C.x14()-Cp.x14(),W.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(C.x15()-Cp.x15(),W.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(C.x16()-Cp.x16(),W.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(C.x21()-Cp.x21(),W.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(C.x22()-Cp.x22(),W.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(C.x23()-Cp.x23(),W.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(C.x24()-Cp.x24(),W.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(C.x25()-Cp.x25(),W.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(C.x26()-Cp.x26(),W.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(C.x31()-Cp.x31(),W.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(C.x32()-Cp.x32(),W.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(C.x33()-Cp.x33(),W.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(C.x34()-Cp.x34(),W.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(C.x35()-Cp.x35(),W.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(C.x36()-Cp.x36(),W.x36()) << "T.x36()";
+    EXPECT_FLOAT_EQ(C.x41()-Cp.x41(),W.x41()) << "T.x41()";
+    EXPECT_FLOAT_EQ(C.x42()-Cp.x42(),W.x42()) << "T.x42()";
+    EXPECT_FLOAT_EQ(C.x43()-Cp.x43(),W.x43()) << "T.x43()";
+    EXPECT_FLOAT_EQ(C.x44()-Cp.x44(),W.x44()) << "T.x44()";
+    EXPECT_FLOAT_EQ(C.x45()-Cp.x45(),W.x45()) << "T.x45()";
+    EXPECT_FLOAT_EQ(C.x46()-Cp.x46(),W.x46()) << "T.x46()";
+    EXPECT_FLOAT_EQ(C.x51()-Cp.x51(),W.x51()) << "T.x51()";
+    EXPECT_FLOAT_EQ(C.x52()-Cp.x52(),W.x52()) << "T.x52()";
+    EXPECT_FLOAT_EQ(C.x53()-Cp.x53(),W.x53()) << "T.x53()";
+    EXPECT_FLOAT_EQ(C.x54()-Cp.x54(),W.x54()) << "T.x54()";
+    EXPECT_FLOAT_EQ(C.x55()-Cp.x55(),W.x55()) << "T.x55()";
+    EXPECT_FLOAT_EQ(C.x56()-Cp.x56(),W.x56()) << "T.x56()";
+    EXPECT_FLOAT_EQ(C.x61()-Cp.x61(),W.x61()) << "T.x61()";
+    EXPECT_FLOAT_EQ(C.x62()-Cp.x62(),W.x62()) << "T.x62()";
+    EXPECT_FLOAT_EQ(C.x63()-Cp.x63(),W.x63()) << "T.x63()";
+    EXPECT_FLOAT_EQ(C.x64()-Cp.x64(),W.x64()) << "T.x64()";
+    EXPECT_FLOAT_EQ(C.x65()-Cp.x65(),W.x65()) << "T.x65()";
+    EXPECT_FLOAT_EQ(C.x66()-Cp.x66(),W.x66()) << "T.x66()";
+}
+
+TEST(mandel_tensors,Basics4thOrderCaddCp){
+
+    TestData td;
+    const auto & C = td.C;
+    const auto & Cp = td.Cp;
+    mandel6x6 W;
+    W = Cp + C;
+
+    EXPECT_FLOAT_EQ(C.x11()+Cp.x11(),W.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(C.x12()+Cp.x12(),W.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(C.x13()+Cp.x13(),W.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(C.x14()+Cp.x14(),W.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(C.x15()+Cp.x15(),W.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(C.x16()+Cp.x16(),W.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(C.x21()+Cp.x21(),W.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(C.x22()+Cp.x22(),W.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(C.x23()+Cp.x23(),W.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(C.x24()+Cp.x24(),W.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(C.x25()+Cp.x25(),W.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(C.x26()+Cp.x26(),W.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(C.x31()+Cp.x31(),W.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(C.x32()+Cp.x32(),W.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(C.x33()+Cp.x33(),W.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(C.x34()+Cp.x34(),W.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(C.x35()+Cp.x35(),W.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(C.x36()+Cp.x36(),W.x36()) << "T.x36()";
+    EXPECT_FLOAT_EQ(C.x41()+Cp.x41(),W.x41()) << "T.x41()";
+    EXPECT_FLOAT_EQ(C.x42()+Cp.x42(),W.x42()) << "T.x42()";
+    EXPECT_FLOAT_EQ(C.x43()+Cp.x43(),W.x43()) << "T.x43()";
+    EXPECT_FLOAT_EQ(C.x44()+Cp.x44(),W.x44()) << "T.x44()";
+    EXPECT_FLOAT_EQ(C.x45()+Cp.x45(),W.x45()) << "T.x45()";
+    EXPECT_FLOAT_EQ(C.x46()+Cp.x46(),W.x46()) << "T.x46()";
+    EXPECT_FLOAT_EQ(C.x51()+Cp.x51(),W.x51()) << "T.x51()";
+    EXPECT_FLOAT_EQ(C.x52()+Cp.x52(),W.x52()) << "T.x52()";
+    EXPECT_FLOAT_EQ(C.x53()+Cp.x53(),W.x53()) << "T.x53()";
+    EXPECT_FLOAT_EQ(C.x54()+Cp.x54(),W.x54()) << "T.x54()";
+    EXPECT_FLOAT_EQ(C.x55()+Cp.x55(),W.x55()) << "T.x55()";
+    EXPECT_FLOAT_EQ(C.x56()+Cp.x56(),W.x56()) << "T.x56()";
+    EXPECT_FLOAT_EQ(C.x61()+Cp.x61(),W.x61()) << "T.x61()";
+    EXPECT_FLOAT_EQ(C.x62()+Cp.x62(),W.x62()) << "T.x62()";
+    EXPECT_FLOAT_EQ(C.x63()+Cp.x63(),W.x63()) << "T.x63()";
+    EXPECT_FLOAT_EQ(C.x64()+Cp.x64(),W.x64()) << "T.x64()";
+    EXPECT_FLOAT_EQ(C.x65()+Cp.x65(),W.x65()) << "T.x65()";
+    EXPECT_FLOAT_EQ(C.x66()+Cp.x66(),W.x66()) << "T.x66()";
+}
+
+TEST(mandel_tensors,Basics4thOrderCminusCp){
+
+    TestData td;
+    const auto & C = td.C;
+    const auto & Cp = td.Cp;
+    mandel6x6 W;
+    W = C - Cp;
+
+    EXPECT_FLOAT_EQ(C.x11()-Cp.x11(),W.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(C.x12()-Cp.x12(),W.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(C.x13()-Cp.x13(),W.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(C.x14()-Cp.x14(),W.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(C.x15()-Cp.x15(),W.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(C.x16()-Cp.x16(),W.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(C.x21()-Cp.x21(),W.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(C.x22()-Cp.x22(),W.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(C.x23()-Cp.x23(),W.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(C.x24()-Cp.x24(),W.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(C.x25()-Cp.x25(),W.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(C.x26()-Cp.x26(),W.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(C.x31()-Cp.x31(),W.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(C.x32()-Cp.x32(),W.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(C.x33()-Cp.x33(),W.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(C.x34()-Cp.x34(),W.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(C.x35()-Cp.x35(),W.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(C.x36()-Cp.x36(),W.x36()) << "T.x36()";
+    EXPECT_FLOAT_EQ(C.x41()-Cp.x41(),W.x41()) << "T.x41()";
+    EXPECT_FLOAT_EQ(C.x42()-Cp.x42(),W.x42()) << "T.x42()";
+    EXPECT_FLOAT_EQ(C.x43()-Cp.x43(),W.x43()) << "T.x43()";
+    EXPECT_FLOAT_EQ(C.x44()-Cp.x44(),W.x44()) << "T.x44()";
+    EXPECT_FLOAT_EQ(C.x45()-Cp.x45(),W.x45()) << "T.x45()";
+    EXPECT_FLOAT_EQ(C.x46()-Cp.x46(),W.x46()) << "T.x46()";
+    EXPECT_FLOAT_EQ(C.x51()-Cp.x51(),W.x51()) << "T.x51()";
+    EXPECT_FLOAT_EQ(C.x52()-Cp.x52(),W.x52()) << "T.x52()";
+    EXPECT_FLOAT_EQ(C.x53()-Cp.x53(),W.x53()) << "T.x53()";
+    EXPECT_FLOAT_EQ(C.x54()-Cp.x54(),W.x54()) << "T.x54()";
+    EXPECT_FLOAT_EQ(C.x55()-Cp.x55(),W.x55()) << "T.x55()";
+    EXPECT_FLOAT_EQ(C.x56()-Cp.x56(),W.x56()) << "T.x56()";
+    EXPECT_FLOAT_EQ(C.x61()-Cp.x61(),W.x61()) << "T.x61()";
+    EXPECT_FLOAT_EQ(C.x62()-Cp.x62(),W.x62()) << "T.x62()";
+    EXPECT_FLOAT_EQ(C.x63()-Cp.x63(),W.x63()) << "T.x63()";
+    EXPECT_FLOAT_EQ(C.x64()-Cp.x64(),W.x64()) << "T.x64()";
+    EXPECT_FLOAT_EQ(C.x65()-Cp.x65(),W.x65()) << "T.x65()";
+    EXPECT_FLOAT_EQ(C.x66()-Cp.x66(),W.x66()) << "T.x66()";
+}                       
+
+TEST(mandel_tensors,Basics4thOrderCxReal){
+
+    TestData td;
+    const auto & C = td.C;
+    const auto & r1 = td.r1;
+    mandel6x6 W = C;
+    W*=r1;
+
+    EXPECT_FLOAT_EQ(C.x11()*r1,W.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(C.x12()*r1,W.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(C.x13()*r1,W.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(C.x14()*r1,W.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(C.x15()*r1,W.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(C.x16()*r1,W.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(C.x21()*r1,W.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(C.x22()*r1,W.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(C.x23()*r1,W.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(C.x24()*r1,W.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(C.x25()*r1,W.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(C.x26()*r1,W.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(C.x31()*r1,W.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(C.x32()*r1,W.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(C.x33()*r1,W.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(C.x34()*r1,W.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(C.x35()*r1,W.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(C.x36()*r1,W.x36()) << "T.x36()";
+    EXPECT_FLOAT_EQ(C.x41()*r1,W.x41()) << "T.x41()";
+    EXPECT_FLOAT_EQ(C.x42()*r1,W.x42()) << "T.x42()";
+    EXPECT_FLOAT_EQ(C.x43()*r1,W.x43()) << "T.x43()";
+    EXPECT_FLOAT_EQ(C.x44()*r1,W.x44()) << "T.x44()";
+    EXPECT_FLOAT_EQ(C.x45()*r1,W.x45()) << "T.x45()";
+    EXPECT_FLOAT_EQ(C.x46()*r1,W.x46()) << "T.x46()";
+    EXPECT_FLOAT_EQ(C.x51()*r1,W.x51()) << "T.x51()";
+    EXPECT_FLOAT_EQ(C.x52()*r1,W.x52()) << "T.x52()";
+    EXPECT_FLOAT_EQ(C.x53()*r1,W.x53()) << "T.x53()";
+    EXPECT_FLOAT_EQ(C.x54()*r1,W.x54()) << "T.x54()";
+    EXPECT_FLOAT_EQ(C.x55()*r1,W.x55()) << "T.x55()";
+    EXPECT_FLOAT_EQ(C.x56()*r1,W.x56()) << "T.x56()";
+    EXPECT_FLOAT_EQ(C.x61()*r1,W.x61()) << "T.x61()";
+    EXPECT_FLOAT_EQ(C.x62()*r1,W.x62()) << "T.x62()";
+    EXPECT_FLOAT_EQ(C.x63()*r1,W.x63()) << "T.x63()";
+    EXPECT_FLOAT_EQ(C.x64()*r1,W.x64()) << "T.x64()";
+    EXPECT_FLOAT_EQ(C.x65()*r1,W.x65()) << "T.x65()";
+    EXPECT_FLOAT_EQ(C.x66()*r1,W.x66()) << "T.x66()";
+}
+
+TEST(mandel_tensors,Basics4thOrderBinaryCxReal){
+
+    TestData td;
+    const auto & C = td.C;
+    const auto & r1 = td.r1;
+    mandel6x6 W;
+    W = C*r1;
+
+    EXPECT_FLOAT_EQ(C.x11()*r1,W.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(C.x12()*r1,W.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(C.x13()*r1,W.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(C.x14()*r1,W.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(C.x15()*r1,W.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(C.x16()*r1,W.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(C.x21()*r1,W.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(C.x22()*r1,W.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(C.x23()*r1,W.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(C.x24()*r1,W.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(C.x25()*r1,W.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(C.x26()*r1,W.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(C.x31()*r1,W.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(C.x32()*r1,W.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(C.x33()*r1,W.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(C.x34()*r1,W.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(C.x35()*r1,W.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(C.x36()*r1,W.x36()) << "T.x36()";
+    EXPECT_FLOAT_EQ(C.x41()*r1,W.x41()) << "T.x41()";
+    EXPECT_FLOAT_EQ(C.x42()*r1,W.x42()) << "T.x42()";
+    EXPECT_FLOAT_EQ(C.x43()*r1,W.x43()) << "T.x43()";
+    EXPECT_FLOAT_EQ(C.x44()*r1,W.x44()) << "T.x44()";
+    EXPECT_FLOAT_EQ(C.x45()*r1,W.x45()) << "T.x45()";
+    EXPECT_FLOAT_EQ(C.x46()*r1,W.x46()) << "T.x46()";
+    EXPECT_FLOAT_EQ(C.x51()*r1,W.x51()) << "T.x51()";
+    EXPECT_FLOAT_EQ(C.x52()*r1,W.x52()) << "T.x52()";
+    EXPECT_FLOAT_EQ(C.x53()*r1,W.x53()) << "T.x53()";
+    EXPECT_FLOAT_EQ(C.x54()*r1,W.x54()) << "T.x54()";
+    EXPECT_FLOAT_EQ(C.x55()*r1,W.x55()) << "T.x55()";
+    EXPECT_FLOAT_EQ(C.x56()*r1,W.x56()) << "T.x56()";
+    EXPECT_FLOAT_EQ(C.x61()*r1,W.x61()) << "T.x61()";
+    EXPECT_FLOAT_EQ(C.x62()*r1,W.x62()) << "T.x62()";
+    EXPECT_FLOAT_EQ(C.x63()*r1,W.x63()) << "T.x63()";
+    EXPECT_FLOAT_EQ(C.x64()*r1,W.x64()) << "T.x64()";
+    EXPECT_FLOAT_EQ(C.x65()*r1,W.x65()) << "T.x65()";
+    EXPECT_FLOAT_EQ(C.x66()*r1,W.x66()) << "T.x66()";
+}
+
+TEST(mandel_tensors,Basics4thOrderBinaryRealxC){
+
+    TestData td;
+    const auto & C = td.C;
+    const auto & r1 = td.r1;
+    mandel6x6 W;
+    W = r1 * C;
+
+    EXPECT_FLOAT_EQ(C.x11()*r1,W.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(C.x12()*r1,W.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(C.x13()*r1,W.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(C.x14()*r1,W.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(C.x15()*r1,W.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(C.x16()*r1,W.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(C.x21()*r1,W.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(C.x22()*r1,W.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(C.x23()*r1,W.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(C.x24()*r1,W.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(C.x25()*r1,W.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(C.x26()*r1,W.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(C.x31()*r1,W.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(C.x32()*r1,W.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(C.x33()*r1,W.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(C.x34()*r1,W.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(C.x35()*r1,W.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(C.x36()*r1,W.x36()) << "T.x36()";
+    EXPECT_FLOAT_EQ(C.x41()*r1,W.x41()) << "T.x41()";
+    EXPECT_FLOAT_EQ(C.x42()*r1,W.x42()) << "T.x42()";
+    EXPECT_FLOAT_EQ(C.x43()*r1,W.x43()) << "T.x43()";
+    EXPECT_FLOAT_EQ(C.x44()*r1,W.x44()) << "T.x44()";
+    EXPECT_FLOAT_EQ(C.x45()*r1,W.x45()) << "T.x45()";
+    EXPECT_FLOAT_EQ(C.x46()*r1,W.x46()) << "T.x46()";
+    EXPECT_FLOAT_EQ(C.x51()*r1,W.x51()) << "T.x51()";
+    EXPECT_FLOAT_EQ(C.x52()*r1,W.x52()) << "T.x52()";
+    EXPECT_FLOAT_EQ(C.x53()*r1,W.x53()) << "T.x53()";
+    EXPECT_FLOAT_EQ(C.x54()*r1,W.x54()) << "T.x54()";
+    EXPECT_FLOAT_EQ(C.x55()*r1,W.x55()) << "T.x55()";
+    EXPECT_FLOAT_EQ(C.x56()*r1,W.x56()) << "T.x56()";
+    EXPECT_FLOAT_EQ(C.x61()*r1,W.x61()) << "T.x61()";
+    EXPECT_FLOAT_EQ(C.x62()*r1,W.x62()) << "T.x62()";
+    EXPECT_FLOAT_EQ(C.x63()*r1,W.x63()) << "T.x63()";
+    EXPECT_FLOAT_EQ(C.x64()*r1,W.x64()) << "T.x64()";
+    EXPECT_FLOAT_EQ(C.x65()*r1,W.x65()) << "T.x65()";
+    EXPECT_FLOAT_EQ(C.x66()*r1,W.x66()) << "T.x66()";
+}
+
+TEST(mandel_tensors,Basics4thOrderCdivReal){
+
+    TestData td;
+    const auto & C = td.C;
+    const auto & r1 = td.r1;
+    mandel6x6 W = C;
+    W/=r1;
+
+    EXPECT_FLOAT_EQ(C.x11()/r1,W.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(C.x12()/r1,W.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(C.x13()/r1,W.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(C.x14()/r1,W.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(C.x15()/r1,W.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(C.x16()/r1,W.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(C.x21()/r1,W.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(C.x22()/r1,W.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(C.x23()/r1,W.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(C.x24()/r1,W.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(C.x25()/r1,W.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(C.x26()/r1,W.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(C.x31()/r1,W.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(C.x32()/r1,W.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(C.x33()/r1,W.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(C.x34()/r1,W.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(C.x35()/r1,W.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(C.x36()/r1,W.x36()) << "T.x36()";
+    EXPECT_FLOAT_EQ(C.x41()/r1,W.x41()) << "T.x41()";
+    EXPECT_FLOAT_EQ(C.x42()/r1,W.x42()) << "T.x42()";
+    EXPECT_FLOAT_EQ(C.x43()/r1,W.x43()) << "T.x43()";
+    EXPECT_FLOAT_EQ(C.x44()/r1,W.x44()) << "T.x44()";
+    EXPECT_FLOAT_EQ(C.x45()/r1,W.x45()) << "T.x45()";
+    EXPECT_FLOAT_EQ(C.x46()/r1,W.x46()) << "T.x46()";
+    EXPECT_FLOAT_EQ(C.x51()/r1,W.x51()) << "T.x51()";
+    EXPECT_FLOAT_EQ(C.x52()/r1,W.x52()) << "T.x52()";
+    EXPECT_FLOAT_EQ(C.x53()/r1,W.x53()) << "T.x53()";
+    EXPECT_FLOAT_EQ(C.x54()/r1,W.x54()) << "T.x54()";
+    EXPECT_FLOAT_EQ(C.x55()/r1,W.x55()) << "T.x55()";
+    EXPECT_FLOAT_EQ(C.x56()/r1,W.x56()) << "T.x56()";
+    EXPECT_FLOAT_EQ(C.x61()/r1,W.x61()) << "T.x61()";
+    EXPECT_FLOAT_EQ(C.x62()/r1,W.x62()) << "T.x62()";
+    EXPECT_FLOAT_EQ(C.x63()/r1,W.x63()) << "T.x63()";
+    EXPECT_FLOAT_EQ(C.x64()/r1,W.x64()) << "T.x64()";
+    EXPECT_FLOAT_EQ(C.x65()/r1,W.x65()) << "T.x65()";
+    EXPECT_FLOAT_EQ(C.x66()/r1,W.x66()) << "T.x66()";
+}
+
+TEST(mandel_tensors,Basics4thOrderBinaryCdivReal){
+
+    TestData td;
+    const auto & C = td.C;
+    const auto & r1 = td.r1;
+    mandel6x6 W;
+    W = C/r1;
+
+    EXPECT_FLOAT_EQ(C.x11()/r1,W.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(C.x12()/r1,W.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(C.x13()/r1,W.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(C.x14()/r1,W.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(C.x15()/r1,W.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(C.x16()/r1,W.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(C.x21()/r1,W.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(C.x22()/r1,W.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(C.x23()/r1,W.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(C.x24()/r1,W.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(C.x25()/r1,W.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(C.x26()/r1,W.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(C.x31()/r1,W.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(C.x32()/r1,W.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(C.x33()/r1,W.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(C.x34()/r1,W.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(C.x35()/r1,W.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(C.x36()/r1,W.x36()) << "T.x36()";
+    EXPECT_FLOAT_EQ(C.x41()/r1,W.x41()) << "T.x41()";
+    EXPECT_FLOAT_EQ(C.x42()/r1,W.x42()) << "T.x42()";
+    EXPECT_FLOAT_EQ(C.x43()/r1,W.x43()) << "T.x43()";
+    EXPECT_FLOAT_EQ(C.x44()/r1,W.x44()) << "T.x44()";
+    EXPECT_FLOAT_EQ(C.x45()/r1,W.x45()) << "T.x45()";
+    EXPECT_FLOAT_EQ(C.x46()/r1,W.x46()) << "T.x46()";
+    EXPECT_FLOAT_EQ(C.x51()/r1,W.x51()) << "T.x51()";
+    EXPECT_FLOAT_EQ(C.x52()/r1,W.x52()) << "T.x52()";
+    EXPECT_FLOAT_EQ(C.x53()/r1,W.x53()) << "T.x53()";
+    EXPECT_FLOAT_EQ(C.x54()/r1,W.x54()) << "T.x54()";
+    EXPECT_FLOAT_EQ(C.x55()/r1,W.x55()) << "T.x55()";
+    EXPECT_FLOAT_EQ(C.x56()/r1,W.x56()) << "T.x56()";
+    EXPECT_FLOAT_EQ(C.x61()/r1,W.x61()) << "T.x61()";
+    EXPECT_FLOAT_EQ(C.x62()/r1,W.x62()) << "T.x62()";
+    EXPECT_FLOAT_EQ(C.x63()/r1,W.x63()) << "T.x63()";
+    EXPECT_FLOAT_EQ(C.x64()/r1,W.x64()) << "T.x64()";
+    EXPECT_FLOAT_EQ(C.x65()/r1,W.x65()) << "T.x65()";
+    EXPECT_FLOAT_EQ(C.x66()/r1,W.x66()) << "T.x66()";
+}
+
+/**************************************************************************
+ * Member function tests for 4th-order MandelTensors
+ *************************************************************************/
+TEST(mandel_tensors,LinAlg4thOrderMembersTransposeC){
+
+    TestData td;
+    const auto & C = td.C;
+    mandel6x6 W = Transpose(C);
+
+    EXPECT_FLOAT_EQ(C.x11(),W.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(C.x21(),W.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(C.x31(),W.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(C.x41(),W.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(C.x51(),W.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(C.x61(),W.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(C.x12(),W.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(C.x22(),W.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(C.x32(),W.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(C.x42(),W.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(C.x52(),W.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(C.x62(),W.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(C.x13(),W.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(C.x23(),W.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(C.x33(),W.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(C.x43(),W.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(C.x53(),W.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(C.x63(),W.x36()) << "T.x36()";
+    EXPECT_FLOAT_EQ(C.x14(),W.x41()) << "T.x41()";
+    EXPECT_FLOAT_EQ(C.x24(),W.x42()) << "T.x42()";
+    EXPECT_FLOAT_EQ(C.x34(),W.x43()) << "T.x43()";
+    EXPECT_FLOAT_EQ(C.x44(),W.x44()) << "T.x44()";
+    EXPECT_FLOAT_EQ(C.x54(),W.x45()) << "T.x45()";
+    EXPECT_FLOAT_EQ(C.x64(),W.x46()) << "T.x46()";
+    EXPECT_FLOAT_EQ(C.x15(),W.x51()) << "T.x51()";
+    EXPECT_FLOAT_EQ(C.x25(),W.x52()) << "T.x52()";
+    EXPECT_FLOAT_EQ(C.x35(),W.x53()) << "T.x53()";
+    EXPECT_FLOAT_EQ(C.x45(),W.x54()) << "T.x54()";
+    EXPECT_FLOAT_EQ(C.x55(),W.x55()) << "T.x55()";
+    EXPECT_FLOAT_EQ(C.x65(),W.x56()) << "T.x56()";
+    EXPECT_FLOAT_EQ(C.x16(),W.x61()) << "T.x61()";
+    EXPECT_FLOAT_EQ(C.x26(),W.x62()) << "T.x62()";
+    EXPECT_FLOAT_EQ(C.x36(),W.x63()) << "T.x63()";
+    EXPECT_FLOAT_EQ(C.x46(),W.x64()) << "T.x64()";
+    EXPECT_FLOAT_EQ(C.x56(),W.x65()) << "T.x65()";
+    EXPECT_FLOAT_EQ(C.x66(),W.x66()) << "T.x66()";
+}
+
+TEST(mandel_tensors,LinAlg4thOrderCxCp){
+
+    TestData td;
+    mandel6x6 W = td.C*td.Cp;
+
+    EXPECT_FLOAT_EQ(3.4324641635231457,W.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(3.1652841587579554,W.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(3.7807607038941047,W.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(4.2929990275344521,W.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(5.6740312379032591,W.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(6.6696446443745385,W.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(2.8842299333474313,W.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(2.5497370745168593,W.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(3.1998897121280914,W.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(3.4733946969525569,W.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(4.9716389699058672,W.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(5.8233675439417523,W.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(2.6320661860595416,W.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(2.2593857295548627,W.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(1.9106598610937264,W.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(2.7578998057721957,W.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(3.6603206355467375,W.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(4.2128432475707616,W.x36()) << "T.x36()";
+    EXPECT_FLOAT_EQ(3.2441769156729801,W.x41()) << "T.x41()";
+    EXPECT_FLOAT_EQ(2.5142287416369151,W.x42()) << "T.x42()";
+    EXPECT_FLOAT_EQ(2.2091631392392084,W.x43()) << "T.x43()";
+    EXPECT_FLOAT_EQ(3.8997518624635563,W.x44()) << "T.x44()";
+    EXPECT_FLOAT_EQ(4.7473966292929779,W.x45()) << "T.x45()";
+    EXPECT_FLOAT_EQ(4.9565477090185430,W.x46()) << "T.x46()";
+    EXPECT_FLOAT_EQ(5.5339581850477266,W.x51()) << "T.x51()";
+    EXPECT_FLOAT_EQ(3.6804177173549402,W.x52()) << "T.x52()";
+    EXPECT_FLOAT_EQ(4.2860776978446804,W.x53()) << "T.x53()";
+    EXPECT_FLOAT_EQ(8.0210977617023076,W.x54()) << "T.x54()";
+    EXPECT_FLOAT_EQ(8.3997855773870853,W.x55()) << "T.x55()";
+    EXPECT_FLOAT_EQ(8.9870653250055597,W.x56()) << "T.x56()";
+    EXPECT_FLOAT_EQ(3.5914517574927998,W.x61()) << "T.x61()";
+    EXPECT_FLOAT_EQ(2.7927266821323165,W.x62()) << "T.x62()";
+    EXPECT_FLOAT_EQ(2.7422796353117542,W.x63()) << "T.x63()";
+    EXPECT_FLOAT_EQ(4.4261334775767400,W.x64()) << "T.x64()";
+    EXPECT_FLOAT_EQ(5.2442699849545713,W.x65()) << "T.x65()";
+    EXPECT_FLOAT_EQ(5.8135596538845116,W.x66()) << "T.x66()";
+}
+
+TEST(mandel_tensors,LinAlg4thOrderdote63xe36){
+
+    TestData td;
+    mandel6x6 W = td.e63*td.e36;
+
+    EXPECT_FLOAT_EQ(0.6481000136992765,W.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(0.4371968248688184,W.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(0.4567401931759338,W.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(0.5084467410380618,W.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(0.8658538452444362,W.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(0.8270178894938859,W.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(0.9406952522707415,W.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(0.2483595248852332,W.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(0.4811208705993483,W.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(0.4424702363903814,W.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(0.4670224166308748,W.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(0.6944279990001526,W.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(0.6348517948283502,W.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(0.1063141324215460,W.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(0.2969290536912734,W.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(0.2262760176533510,W.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(0.2549385207966328,W.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(0.4362317224266326,W.x36()) << "T.x36()";
+    EXPECT_FLOAT_EQ(0.5209422981631543,W.x41()) << "T.x41()";
+    EXPECT_FLOAT_EQ(0.1946090556325360,W.x42()) << "T.x42()";
+    EXPECT_FLOAT_EQ(0.2929761942755778,W.x43()) << "T.x43()";
+    EXPECT_FLOAT_EQ(0.2963774815244760,W.x44()) << "T.x44()";
+    EXPECT_FLOAT_EQ(0.3556848018688814,W.x45()) << "T.x45()";
+    EXPECT_FLOAT_EQ(0.4448801241685245,W.x46()) << "T.x46()";
+    EXPECT_FLOAT_EQ(0.6706444943197795,W.x51()) << "T.x51()";
+    EXPECT_FLOAT_EQ(0.4484542729222799,W.x52()) << "T.x52()";
+    EXPECT_FLOAT_EQ(0.4695062540258030,W.x53()) << "T.x53()";
+    EXPECT_FLOAT_EQ(0.5525554002871033,W.x54()) << "T.x54()";
+    EXPECT_FLOAT_EQ(0.8125274881895002,W.x55()) << "T.x55()";
+    EXPECT_FLOAT_EQ(0.7951750536126074,W.x56()) << "T.x56()";
+    EXPECT_FLOAT_EQ(0.3032681701367076,W.x61()) << "T.x61()";
+    EXPECT_FLOAT_EQ(0.1981818384668978,W.x62()) << "T.x62()";
+    EXPECT_FLOAT_EQ(0.2104566600814864,W.x63()) << "T.x63()";
+    EXPECT_FLOAT_EQ(0.2389951119718454,W.x64()) << "T.x64()";
+    EXPECT_FLOAT_EQ(0.3767984844926149,W.x65()) << "T.x65()";
+    EXPECT_FLOAT_EQ(0.3673680488195881,W.x66()) << "T.x66()";
+}
+
+/**************************************************************************
+ * Constructor tests for 3rd order tensors (MandelTensor36)
+ *************************************************************************/
+TEST(mandel_tensors,Construct36e36fromListxform){
+
+    TestData td;
+    const auto & e36 = td.e36;
+
+    //already completed in initlization
+    EXPECT_FLOAT_EQ(0.8076127837790422,e36.x11()) << "e36.x11()";
+    EXPECT_FLOAT_EQ(0.0119054861420681,e36.x12()) << "e36.x12()";
+    EXPECT_FLOAT_EQ(0.3198164644230427,e36.x13()) << "e36.x13()";
+    EXPECT_FLOAT_EQ(0.1899714025547371,e36.x14()) << "e36.x14()";
+    EXPECT_FLOAT_EQ(0.0810795183410036,e36.x15()) << "e36.x15()";
+    EXPECT_FLOAT_EQ(0.3999599660633990,e36.x16()) << "e36.x16()";
+    EXPECT_FLOAT_EQ(0.0453167988352610,e36.x21()) << "e36.x21()";
+    EXPECT_FLOAT_EQ(0.2818248347311008,e36.x22()) << "e36.x22()";
+    EXPECT_FLOAT_EQ(0.1508671814551668,e36.x23()) << "e36.x23()";
+    EXPECT_FLOAT_EQ(0.2127405166893033,e36.x24()) << "e36.x24()";
+    EXPECT_FLOAT_EQ(0.6128683635764686,e36.x25()) << "e36.x25()";
+    EXPECT_FLOAT_EQ(0.4153444264017785,e36.x26()) << "e36.x26()";
+    EXPECT_FLOAT_EQ(0.5405046604793561,e36.x31()) << "e36.x31()";
+    EXPECT_FLOAT_EQ(0.4391783723249735,e36.x32()) << "e36.x32()";
+    EXPECT_FLOAT_EQ(0.4128631387354691,e36.x33()) << "e36.x33()";
+    EXPECT_FLOAT_EQ(0.5546654249524924,e36.x34()) << "e36.x34()";
+    EXPECT_FLOAT_EQ(0.6862523687819362,e36.x35()) << "e36.x35()";
+    EXPECT_FLOAT_EQ(0.6488819206134113,e36.x36()) << "e36.x36()";
+}
+
+TEST(mandel_tensors,Construct36e36frome36){
+
+    TestData td;
+    const auto & e36(td.e36);
+
+    //already completed in initlization
+    EXPECT_FLOAT_EQ(0.8076127837790422,e36.x11()) << "e36.x11()";
+    EXPECT_FLOAT_EQ(0.0119054861420681,e36.x12()) << "e36.x12()";
+    EXPECT_FLOAT_EQ(0.3198164644230427,e36.x13()) << "e36.x13()";
+    EXPECT_FLOAT_EQ(0.1899714025547371,e36.x14()) << "e36.x14()";
+    EXPECT_FLOAT_EQ(0.0810795183410036,e36.x15()) << "e36.x15()";
+    EXPECT_FLOAT_EQ(0.3999599660633990,e36.x16()) << "e36.x16()";
+    EXPECT_FLOAT_EQ(0.0453167988352610,e36.x21()) << "e36.x21()";
+    EXPECT_FLOAT_EQ(0.2818248347311008,e36.x22()) << "e36.x22()";
+    EXPECT_FLOAT_EQ(0.1508671814551668,e36.x23()) << "e36.x23()";
+    EXPECT_FLOAT_EQ(0.2127405166893033,e36.x24()) << "e36.x24()";
+    EXPECT_FLOAT_EQ(0.6128683635764686,e36.x25()) << "e36.x25()";
+    EXPECT_FLOAT_EQ(0.4153444264017785,e36.x26()) << "e36.x26()";
+    EXPECT_FLOAT_EQ(0.5405046604793561,e36.x31()) << "e36.x31()";
+    EXPECT_FLOAT_EQ(0.4391783723249735,e36.x32()) << "e36.x32()";
+    EXPECT_FLOAT_EQ(0.4128631387354691,e36.x33()) << "e36.x33()";
+    EXPECT_FLOAT_EQ(0.5546654249524924,e36.x34()) << "e36.x34()";
+    EXPECT_FLOAT_EQ(0.6862523687819362,e36.x35()) << "e36.x35()";
+    EXPECT_FLOAT_EQ(0.6488819206134113,e36.x36()) << "e36.x36()";
+}
+
+TEST(mandel_tensors,Construct36e36frome36Xform){
+
+    TestData td;
+    const auto & e36invX = td.e36invX;
+    mandel3x6 e(td.e36);
+    e.invMandelXform();
+
+    EXPECT_FLOAT_EQ(e36invX.x11(),e.x11()) << "e36.x11()";
+    EXPECT_FLOAT_EQ(e36invX.x12(),e.x12()) << "e36.x12()";
+    EXPECT_FLOAT_EQ(e36invX.x13(),e.x13()) << "e36.x13()";
+    EXPECT_FLOAT_EQ(e36invX.x14(),e.x14()) << "e36.x14()";
+    EXPECT_FLOAT_EQ(e36invX.x15(),e.x15()) << "e36.x15()";
+    EXPECT_FLOAT_EQ(e36invX.x16(),e.x16()) << "e36.x16()";
+    EXPECT_FLOAT_EQ(e36invX.x21(),e.x21()) << "e36.x21()";
+    EXPECT_FLOAT_EQ(e36invX.x22(),e.x22()) << "e36.x22()";
+    EXPECT_FLOAT_EQ(e36invX.x23(),e.x23()) << "e36.x23()";
+    EXPECT_FLOAT_EQ(e36invX.x24(),e.x24()) << "e36.x24()";
+    EXPECT_FLOAT_EQ(e36invX.x25(),e.x25()) << "e36.x25()";
+    EXPECT_FLOAT_EQ(e36invX.x26(),e.x26()) << "e36.x26()";
+    EXPECT_FLOAT_EQ(e36invX.x31(),e.x31()) << "e36.x31()";
+    EXPECT_FLOAT_EQ(e36invX.x32(),e.x32()) << "e36.x32()";
+    EXPECT_FLOAT_EQ(e36invX.x33(),e.x33()) << "e36.x33()";
+    EXPECT_FLOAT_EQ(e36invX.x34(),e.x34()) << "e36.x34()";
+    EXPECT_FLOAT_EQ(e36invX.x35(),e.x35()) << "e36.x35()";
+    EXPECT_FLOAT_EQ(e36invX.x36(),e.x36()) << "e36.x36()";
+}
+
+TEST(mandel_tensors,Construct36e36fromList){
+
+    TestData td;
+    const auto & e36invX = td.e36invX;
+    mandel3x6 e = td.e36;
+    e.invMandelXform();
+
+    EXPECT_FLOAT_EQ(e36invX.x11(),e.x11()) << "e36.x11()";
+    EXPECT_FLOAT_EQ(e36invX.x12(),e.x12()) << "e36.x12()";
+    EXPECT_FLOAT_EQ(e36invX.x13(),e.x13()) << "e36.x13()";
+    EXPECT_FLOAT_EQ(e36invX.x14(),e.x14()) << "e36.x14()";
+    EXPECT_FLOAT_EQ(e36invX.x15(),e.x15()) << "e36.x15()";
+    EXPECT_FLOAT_EQ(e36invX.x16(),e.x16()) << "e36.x16()";
+    EXPECT_FLOAT_EQ(e36invX.x21(),e.x21()) << "e36.x21()";
+    EXPECT_FLOAT_EQ(e36invX.x22(),e.x22()) << "e36.x22()";
+    EXPECT_FLOAT_EQ(e36invX.x23(),e.x23()) << "e36.x23()";
+    EXPECT_FLOAT_EQ(e36invX.x24(),e.x24()) << "e36.x24()";
+    EXPECT_FLOAT_EQ(e36invX.x25(),e.x25()) << "e36.x25()";
+    EXPECT_FLOAT_EQ(e36invX.x26(),e.x26()) << "e36.x26()";
+    EXPECT_FLOAT_EQ(e36invX.x31(),e.x31()) << "e36.x31()";
+    EXPECT_FLOAT_EQ(e36invX.x32(),e.x32()) << "e36.x32()";
+    EXPECT_FLOAT_EQ(e36invX.x33(),e.x33()) << "e36.x33()";
+    EXPECT_FLOAT_EQ(e36invX.x34(),e.x34()) << "e36.x34()";
+    EXPECT_FLOAT_EQ(e36invX.x35(),e.x35()) << "e36.x35()";
+    EXPECT_FLOAT_EQ(e36invX.x36(),e.x36()) << "e36.x36()";
+}
+
+/**************************************************************************
+ * Basic Operations for 3rd order Tensor (MandelTensor36)
+ *************************************************************************/
+TEST(mandel_tensors,Basic3rdOrder36e36pluseqe36p){
+
+    TestData td;
+    const auto & e36p = td.e36p;
+    const auto & e36 = td.e36;
+    mandel3x6 e = e36;
+    e+=e36p;
+
+    EXPECT_FLOAT_EQ(e36.x11()+e36p.x11(),e.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(e36.x12()+e36p.x12(),e.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(e36.x13()+e36p.x13(),e.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(e36.x14()+e36p.x14(),e.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(e36.x15()+e36p.x15(),e.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(e36.x16()+e36p.x16(),e.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(e36.x21()+e36p.x21(),e.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(e36.x22()+e36p.x22(),e.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(e36.x23()+e36p.x23(),e.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(e36.x24()+e36p.x24(),e.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(e36.x25()+e36p.x25(),e.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(e36.x26()+e36p.x26(),e.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(e36.x31()+e36p.x31(),e.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(e36.x32()+e36p.x32(),e.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(e36.x33()+e36p.x33(),e.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(e36.x34()+e36p.x34(),e.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(e36.x35()+e36p.x35(),e.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(e36.x36()+e36p.x36(),e.x36()) << "T.x36()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder36e36add36p){
+
+    TestData td;
+    const auto & e36p = td.e36p;
+    const auto & e36 = td.e36;
+    mandel3x6 e;
+    e = e36 + e36p;
+
+    EXPECT_FLOAT_EQ(e36.x11()+e36p.x11(),e.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(e36.x12()+e36p.x12(),e.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(e36.x13()+e36p.x13(),e.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(e36.x14()+e36p.x14(),e.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(e36.x15()+e36p.x15(),e.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(e36.x16()+e36p.x16(),e.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(e36.x21()+e36p.x21(),e.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(e36.x22()+e36p.x22(),e.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(e36.x23()+e36p.x23(),e.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(e36.x24()+e36p.x24(),e.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(e36.x25()+e36p.x25(),e.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(e36.x26()+e36p.x26(),e.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(e36.x31()+e36p.x31(),e.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(e36.x32()+e36p.x32(),e.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(e36.x33()+e36p.x33(),e.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(e36.x34()+e36p.x34(),e.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(e36.x35()+e36p.x35(),e.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(e36.x36()+e36p.x36(),e.x36()) << "T.x36()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder36e36minus36p){
+
+    TestData td;
+    const auto & e36p = td.e36p;
+    const auto & e36 = td.e36;
+    mandel3x6 e;
+    e = e36 - e36p;
+
+    EXPECT_FLOAT_EQ(e36.x11()-e36p.x11(),e.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(e36.x12()-e36p.x12(),e.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(e36.x13()-e36p.x13(),e.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(e36.x14()-e36p.x14(),e.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(e36.x15()-e36p.x15(),e.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(e36.x16()-e36p.x16(),e.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(e36.x21()-e36p.x21(),e.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(e36.x22()-e36p.x22(),e.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(e36.x23()-e36p.x23(),e.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(e36.x24()-e36p.x24(),e.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(e36.x25()-e36p.x25(),e.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(e36.x26()-e36p.x26(),e.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(e36.x31()-e36p.x31(),e.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(e36.x32()-e36p.x32(),e.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(e36.x33()-e36p.x33(),e.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(e36.x34()-e36p.x34(),e.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(e36.x35()-e36p.x35(),e.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(e36.x36()-e36p.x36(),e.x36()) << "T.x36()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder36e36xreal){
+
+    TestData td;
+    const auto & e36 = td.e36;
+    const auto & r1 = td.r1;
+    mandel3x6 e = e36;
+    e*=r1;
+
+    EXPECT_FLOAT_EQ(e36.x11()*r1,e.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(e36.x12()*r1,e.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(e36.x13()*r1,e.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(e36.x14()*r1,e.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(e36.x15()*r1,e.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(e36.x16()*r1,e.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(e36.x21()*r1,e.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(e36.x22()*r1,e.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(e36.x23()*r1,e.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(e36.x24()*r1,e.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(e36.x25()*r1,e.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(e36.x26()*r1,e.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(e36.x31()*r1,e.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(e36.x32()*r1,e.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(e36.x33()*r1,e.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(e36.x34()*r1,e.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(e36.x35()*r1,e.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(e36.x36()*r1,e.x36()) << "T.x36()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder36Binarye36xreal){
+
+    TestData td;
+    const auto & e36 = td.e36;
+    const auto & r1 = td.r1;
+    mandel3x6 e;
+    e = e36*r1;
+
+    EXPECT_FLOAT_EQ(e36.x11()*r1,e.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(e36.x12()*r1,e.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(e36.x13()*r1,e.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(e36.x14()*r1,e.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(e36.x15()*r1,e.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(e36.x16()*r1,e.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(e36.x21()*r1,e.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(e36.x22()*r1,e.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(e36.x23()*r1,e.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(e36.x24()*r1,e.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(e36.x25()*r1,e.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(e36.x26()*r1,e.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(e36.x31()*r1,e.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(e36.x32()*r1,e.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(e36.x33()*r1,e.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(e36.x34()*r1,e.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(e36.x35()*r1,e.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(e36.x36()*r1,e.x36()) << "T.x36()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder36Binaryrealxe36){
+
+    TestData td;
+    const auto & e36 = td.e36;
+    const auto & r1 = td.r1;
+    mandel3x6 e;
+    e= r1 * e36;
+
+    EXPECT_FLOAT_EQ(e36.x11()*r1,e.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(e36.x12()*r1,e.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(e36.x13()*r1,e.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(e36.x14()*r1,e.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(e36.x15()*r1,e.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(e36.x16()*r1,e.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(e36.x21()*r1,e.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(e36.x22()*r1,e.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(e36.x23()*r1,e.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(e36.x24()*r1,e.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(e36.x25()*r1,e.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(e36.x26()*r1,e.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(e36.x31()*r1,e.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(e36.x32()*r1,e.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(e36.x33()*r1,e.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(e36.x34()*r1,e.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(e36.x35()*r1,e.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(e36.x36()*r1,e.x36()) << "T.x36()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder36e36divreal){
+    TestData td;
+    const auto & e36 = td.e36;
+    const auto & r1 = td.r1;
+    mandel3x6 e = e36;
+    e/=r1;
+
+    EXPECT_FLOAT_EQ(e36.x11()/r1,e.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(e36.x12()/r1,e.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(e36.x13()/r1,e.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(e36.x14()/r1,e.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(e36.x15()/r1,e.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(e36.x16()/r1,e.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(e36.x21()/r1,e.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(e36.x22()/r1,e.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(e36.x23()/r1,e.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(e36.x24()/r1,e.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(e36.x25()/r1,e.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(e36.x26()/r1,e.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(e36.x31()/r1,e.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(e36.x32()/r1,e.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(e36.x33()/r1,e.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(e36.x34()/r1,e.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(e36.x35()/r1,e.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(e36.x36()/r1,e.x36()) << "T.x36()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder36Binarye36divreal){
+    TestData td;
+    const auto & e36 = td.e36;
+    const auto & r1 = td.r1;
+    mandel3x6 e;
+    e = e36 / r1;
+
+    EXPECT_FLOAT_EQ(e36.x11()/r1,e.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(e36.x12()/r1,e.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(e36.x13()/r1,e.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(e36.x14()/r1,e.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(e36.x15()/r1,e.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(e36.x16()/r1,e.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(e36.x21()/r1,e.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(e36.x22()/r1,e.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(e36.x23()/r1,e.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(e36.x24()/r1,e.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(e36.x25()/r1,e.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(e36.x26()/r1,e.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(e36.x31()/r1,e.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(e36.x32()/r1,e.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(e36.x33()/r1,e.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(e36.x34()/r1,e.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(e36.x35()/r1,e.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(e36.x36()/r1,e.x36()) << "T.x36()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder36e36minuseqe36p){
+
+    TestData td;
+    const auto & e36p = td.e36p;
+    const auto & e36 = td.e36;
+    mandel3x6 e = e36;
+    e-=e36p;
+
+    EXPECT_FLOAT_EQ(e36.x11()-e36p.x11(),e.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(e36.x12()-e36p.x12(),e.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(e36.x13()-e36p.x13(),e.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(e36.x14()-e36p.x14(),e.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(e36.x15()-e36p.x15(),e.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(e36.x16()-e36p.x16(),e.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(e36.x21()-e36p.x21(),e.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(e36.x22()-e36p.x22(),e.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(e36.x23()-e36p.x23(),e.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(e36.x24()-e36p.x24(),e.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(e36.x25()-e36p.x25(),e.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(e36.x26()-e36p.x26(),e.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(e36.x31()-e36p.x31(),e.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(e36.x32()-e36p.x32(),e.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(e36.x33()-e36p.x33(),e.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(e36.x34()-e36p.x34(),e.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(e36.x35()-e36p.x35(),e.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(e36.x36()-e36p.x36(),e.x36()) << "T.x36()";
+}
+
+/**************************************************************************
+ * Linear Algegra Operations for 3rd order Tensor (MandelTensor36)
+ *************************************************************************/
+TEST(mandel_tensors,LinAlg3rdOrder36Transposee36){
+
+    TestData td;
+    const auto & e36 = td.e36;
+    mandel6x3 e = Transpose(e36);
+
+    EXPECT_FLOAT_EQ(e36.x11(),e.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(e36.x21(),e.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(e36.x31(),e.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(e36.x12(),e.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(e36.x22(),e.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(e36.x32(),e.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(e36.x13(),e.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(e36.x23(),e.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(e36.x33(),e.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(e36.x14(),e.x41()) << "T.x41()";
+    EXPECT_FLOAT_EQ(e36.x24(),e.x42()) << "T.x42()";
+    EXPECT_FLOAT_EQ(e36.x34(),e.x43()) << "T.x43()";
+    EXPECT_FLOAT_EQ(e36.x15(),e.x51()) << "T.x51()";
+    EXPECT_FLOAT_EQ(e36.x25(),e.x52()) << "T.x52()";
+    EXPECT_FLOAT_EQ(e36.x35(),e.x53()) << "T.x53()";
+    EXPECT_FLOAT_EQ(e36.x16(),e.x61()) << "T.x61()";
+    EXPECT_FLOAT_EQ(e36.x26(),e.x62()) << "T.x62()";
+    EXPECT_FLOAT_EQ(e36.x36(),e.x63()) << "T.x63()";
+}
+
+TEST(mandel_tensors,LinAlg3rdOrder36e36xC){
+
+    TestData td;
+    mandel3x6 e = td.e36*td.C;
+
+    EXPECT_FLOAT_EQ(0.4360318402861528,e.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(0.9345405556169891,e.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(1.1294252960227749,e.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(1.7197078302986348,e.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(1.3479430797635792,e.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(1.9283632491846265,e.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(0.2405601714884583,e.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(1.3601489642543370,e.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(1.1651977924898005,e.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(1.9322848070700853,e.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(1.8562241288914805,e.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(1.5746750476550175,e.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(0.5874503614638639,e.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(2.2398682875834326,e.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(2.1734397351857577,e.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(3.3176192350877933,e.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(2.9597619531868462,e.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(3.1532472154198636,e.x36()) << "T.x36()";
+}
+
+TEST(mandel_tensors,LinAlg3rdOrder36Vxe36){
+
+    TestData td;
+    mandel3x6 e = td.V*td.e36;
+
+    EXPECT_FLOAT_EQ(0.3185304284465936,e.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(0.2361092230446556,e.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(0.2355231336813478,e.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(0.2417284861372397,e.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(0.5314586051186603,e.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(0.4802443010730050,e.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(1.1893596817424412,e.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(0.4783014754499950,e.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(0.6839526055434930,e.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(0.7246316530324255,e.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(0.8253436509360010,e.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(1.0188784876197137,e.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(0.3723594325967821,e.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(0.5368235788575713,e.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(0.3956192828621352,e.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(0.5402554081049711,e.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(1.0058471318300359,e.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(0.7936784286137580,e.x36()) << "T.x36()";
+}
+
+TEST(mandel_tensors,LinAlg3rdOrder36TensorVxe36){
+
+    TestData td;
+    mandel3x6 e = td.TV*td.e36;
+
+    EXPECT_FLOAT_EQ(0.3185304284465936,e.x11()) << "T.x11()";
+    EXPECT_FLOAT_EQ(0.2361092230446556,e.x12()) << "T.x12()";
+    EXPECT_FLOAT_EQ(0.2355231336813478,e.x13()) << "T.x13()";
+    EXPECT_FLOAT_EQ(0.2417284861372397,e.x14()) << "T.x14()";
+    EXPECT_FLOAT_EQ(0.5314586051186603,e.x15()) << "T.x15()";
+    EXPECT_FLOAT_EQ(0.4802443010730050,e.x16()) << "T.x16()";
+    EXPECT_FLOAT_EQ(1.1893596817424412,e.x21()) << "T.x21()";
+    EXPECT_FLOAT_EQ(0.4783014754499950,e.x22()) << "T.x22()";
+    EXPECT_FLOAT_EQ(0.6839526055434930,e.x23()) << "T.x23()";
+    EXPECT_FLOAT_EQ(0.7246316530324255,e.x24()) << "T.x24()";
+    EXPECT_FLOAT_EQ(0.8253436509360010,e.x25()) << "T.x25()";
+    EXPECT_FLOAT_EQ(1.0188784876197137,e.x26()) << "T.x26()";
+    EXPECT_FLOAT_EQ(0.3723594325967821,e.x31()) << "T.x31()";
+    EXPECT_FLOAT_EQ(0.5368235788575713,e.x32()) << "T.x32()";
+    EXPECT_FLOAT_EQ(0.3956192828621352,e.x33()) << "T.x33()";
+    EXPECT_FLOAT_EQ(0.5402554081049711,e.x34()) << "T.x34()";
+    EXPECT_FLOAT_EQ(1.0058471318300359,e.x35()) << "T.x35()";
+    EXPECT_FLOAT_EQ(0.7936784286137580,e.x36()) << "T.x36()";
+}
+
+/**************************************************************************
+ * Constructor Tests for 3rd order Tensor (MandelTensor63)
+ *************************************************************************/
+TEST(mandel_tensors,Construct63e63fromListxform){
+
+    //already done in setup
+    TestData td;
+    const auto & e63 = td.e63;
+
+    EXPECT_FLOAT_EQ(0.4759634421237341,e63.x11()) << "e63.x11()";
+    EXPECT_FLOAT_EQ(0.8867644229624673,e63.x12()) << "e63.x12()";
+    EXPECT_FLOAT_EQ(0.4135404273124733,e63.x13()) << "e63.x13()";
+    EXPECT_FLOAT_EQ(0.8568504365470173,e63.x21()) << "e63.x21()";
+    EXPECT_FLOAT_EQ(0.1472947329145138,e63.x22()) << "e63.x22()";
+    EXPECT_FLOAT_EQ(0.4477610978101461,e63.x23()) << "e63.x23()";
+    EXPECT_FLOAT_EQ(0.7307484706668289,e63.x31()) << "e63.x31()";
+    EXPECT_FLOAT_EQ(0.2502091219941188,e63.x32()) << "e63.x32()";
+    EXPECT_FLOAT_EQ(0.0617040225205491,e63.x33()) << "e63.x33()";
+    EXPECT_FLOAT_EQ(0.4119163419942556,e63.x41()) << "e63.x41()";
+    EXPECT_FLOAT_EQ(0.1499018857533562,e63.x42()) << "e63.x42()";
+    EXPECT_FLOAT_EQ(0.3357608808746134,e63.x43()) << "e63.x43()";
+    EXPECT_FLOAT_EQ(0.3481855982554204,e63.x51()) << "e63.x51()";
+    EXPECT_FLOAT_EQ(0.5219168123093268,e63.x52()) << "e63.x52()";
+    EXPECT_FLOAT_EQ(0.6767633687457478,e63.x53()) << "e63.x53()";
+    EXPECT_FLOAT_EQ(0.1958577356414437,e63.x61()) << "e63.x61()";
+    EXPECT_FLOAT_EQ(0.3181944873075155,e63.x62()) << "e63.x62()";
+    EXPECT_FLOAT_EQ(0.2417581438483243,e63.x63()) << "e63.x63()";
+}
+
+TEST(mandel_tensors,Construct63e63frome63Xform){
+
+    //already done in setup
+    TestData td;
+    const auto & e63(td.e63);
+
+    EXPECT_FLOAT_EQ(0.4759634421237341,e63.x11()) << "e63.x11()";
+    EXPECT_FLOAT_EQ(0.8867644229624673,e63.x12()) << "e63.x12()";
+    EXPECT_FLOAT_EQ(0.4135404273124733,e63.x13()) << "e63.x13()";
+    EXPECT_FLOAT_EQ(0.8568504365470173,e63.x21()) << "e63.x21()";
+    EXPECT_FLOAT_EQ(0.1472947329145138,e63.x22()) << "e63.x22()";
+    EXPECT_FLOAT_EQ(0.4477610978101461,e63.x23()) << "e63.x23()";
+    EXPECT_FLOAT_EQ(0.7307484706668289,e63.x31()) << "e63.x31()";
+    EXPECT_FLOAT_EQ(0.2502091219941188,e63.x32()) << "e63.x32()";
+    EXPECT_FLOAT_EQ(0.0617040225205491,e63.x33()) << "e63.x33()";
+    EXPECT_FLOAT_EQ(0.4119163419942556,e63.x41()) << "e63.x41()";
+    EXPECT_FLOAT_EQ(0.1499018857533562,e63.x42()) << "e63.x42()";
+    EXPECT_FLOAT_EQ(0.3357608808746134,e63.x43()) << "e63.x43()";
+    EXPECT_FLOAT_EQ(0.3481855982554204,e63.x51()) << "e63.x51()";
+    EXPECT_FLOAT_EQ(0.5219168123093268,e63.x52()) << "e63.x52()";
+    EXPECT_FLOAT_EQ(0.6767633687457478,e63.x53()) << "e63.x53()";
+    EXPECT_FLOAT_EQ(0.1958577356414437,e63.x61()) << "e63.x61()";
+    EXPECT_FLOAT_EQ(0.3181944873075155,e63.x62()) << "e63.x62()";
+    EXPECT_FLOAT_EQ(0.2417581438483243,e63.x63()) << "e63.x63()";
+}
+
+TEST(mandel_tensors,Construct63e63frome63){
+
+    TestData td;
+    const auto e63invX = td.e63invX;
+    mandel6x3 f(td.e63);
+    f.invMandelXform();
+
+    EXPECT_FLOAT_EQ(e63invX.x11(),f.x11()) << "x11()";
+    EXPECT_FLOAT_EQ(e63invX.x12(),f.x12()) << "x12()";
+    EXPECT_FLOAT_EQ(e63invX.x13(),f.x13()) << "x13()";
+    EXPECT_FLOAT_EQ(e63invX.x21(),f.x21()) << "x21()";
+    EXPECT_FLOAT_EQ(e63invX.x22(),f.x22()) << "x22()";
+    EXPECT_FLOAT_EQ(e63invX.x23(),f.x23()) << "x23()";
+    EXPECT_FLOAT_EQ(e63invX.x31(),f.x31()) << "x31()";
+    EXPECT_FLOAT_EQ(e63invX.x32(),f.x32()) << "x32()";
+    EXPECT_FLOAT_EQ(e63invX.x33(),f.x33()) << "x33()";
+    EXPECT_FLOAT_EQ(e63invX.x41(),f.x41()) << "x41()";
+    EXPECT_FLOAT_EQ(e63invX.x42(),f.x42()) << "x42()";
+    EXPECT_FLOAT_EQ(e63invX.x43(),f.x43()) << "x43()";
+    EXPECT_FLOAT_EQ(e63invX.x51(),f.x51()) << "x51()";
+    EXPECT_FLOAT_EQ(e63invX.x52(),f.x52()) << "x52()";
+    EXPECT_FLOAT_EQ(e63invX.x53(),f.x53()) << "x53()";
+    EXPECT_FLOAT_EQ(e63invX.x61(),f.x61()) << "x61()";
+    EXPECT_FLOAT_EQ(e63invX.x62(),f.x62()) << "x62()";
+    EXPECT_FLOAT_EQ(e63invX.x63(),f.x63()) << "x63()";
+}
+
+TEST(mandel_tensors,Construct63e63fromList){
+
+    TestData td;
+    const auto e63invX = td.e63invX;
+    mandel6x3 f = td.e63;
+    f.invMandelXform();
+
+    EXPECT_FLOAT_EQ(e63invX.x11(),f.x11()) << "x11()";
+    EXPECT_FLOAT_EQ(e63invX.x12(),f.x12()) << "x12()";
+    EXPECT_FLOAT_EQ(e63invX.x13(),f.x13()) << "x13()";
+    EXPECT_FLOAT_EQ(e63invX.x21(),f.x21()) << "x21()";
+    EXPECT_FLOAT_EQ(e63invX.x22(),f.x22()) << "x22()";
+    EXPECT_FLOAT_EQ(e63invX.x23(),f.x23()) << "x23()";
+    EXPECT_FLOAT_EQ(e63invX.x31(),f.x31()) << "x31()";
+    EXPECT_FLOAT_EQ(e63invX.x32(),f.x32()) << "x32()";
+    EXPECT_FLOAT_EQ(e63invX.x33(),f.x33()) << "x33()";
+    EXPECT_FLOAT_EQ(e63invX.x41(),f.x41()) << "x41()";
+    EXPECT_FLOAT_EQ(e63invX.x42(),f.x42()) << "x42()";
+    EXPECT_FLOAT_EQ(e63invX.x43(),f.x43()) << "x43()";
+    EXPECT_FLOAT_EQ(e63invX.x51(),f.x51()) << "x51()";
+    EXPECT_FLOAT_EQ(e63invX.x52(),f.x52()) << "x52()";
+    EXPECT_FLOAT_EQ(e63invX.x53(),f.x53()) << "x53()";
+    EXPECT_FLOAT_EQ(e63invX.x61(),f.x61()) << "x61()";
+    EXPECT_FLOAT_EQ(e63invX.x62(),f.x62()) << "x62()";
+    EXPECT_FLOAT_EQ(e63invX.x63(),f.x63()) << "x63()";
+}
+
+/**************************************************************************
+ * Basic Operations for 3rd order Tensor (MandelTensor63)
+ *************************************************************************/
+TEST(mandel_tensors,Basic3rdOrder63e63pluseqe63p){
+
+    TestData td;
+    const auto & e63 = td.e63;
+    const auto & e63p = td.e63p;
+    mandel6x3 f = e63;
+    f+=e63p;
+
+    EXPECT_FLOAT_EQ(e63.x11()+e63p.x11(),f.x11()) << "e.x11()";
+    EXPECT_FLOAT_EQ(e63.x12()+e63p.x12(),f.x12()) << "e.x12()";
+    EXPECT_FLOAT_EQ(e63.x13()+e63p.x13(),f.x13()) << "e.x13()";
+    EXPECT_FLOAT_EQ(e63.x21()+e63p.x21(),f.x21()) << "e.x21()";
+    EXPECT_FLOAT_EQ(e63.x22()+e63p.x22(),f.x22()) << "e.x22()";
+    EXPECT_FLOAT_EQ(e63.x23()+e63p.x23(),f.x23()) << "e.x23()";
+    EXPECT_FLOAT_EQ(e63.x31()+e63p.x31(),f.x31()) << "e.x31()";
+    EXPECT_FLOAT_EQ(e63.x32()+e63p.x32(),f.x32()) << "e.x32()";
+    EXPECT_FLOAT_EQ(e63.x33()+e63p.x33(),f.x33()) << "e.x33()";
+    EXPECT_FLOAT_EQ(e63.x41()+e63p.x41(),f.x41()) << "e.x41()";
+    EXPECT_FLOAT_EQ(e63.x42()+e63p.x42(),f.x42()) << "e.x42()";
+    EXPECT_FLOAT_EQ(e63.x43()+e63p.x43(),f.x43()) << "e.x43()";
+    EXPECT_FLOAT_EQ(e63.x51()+e63p.x51(),f.x51()) << "e.x51()";
+    EXPECT_FLOAT_EQ(e63.x52()+e63p.x52(),f.x52()) << "e.x52()";
+    EXPECT_FLOAT_EQ(e63.x53()+e63p.x53(),f.x53()) << "e.x53()";
+    EXPECT_FLOAT_EQ(e63.x61()+e63p.x61(),f.x61()) << "e.x61()";
+    EXPECT_FLOAT_EQ(e63.x62()+e63p.x62(),f.x62()) << "e.x62()";
+    EXPECT_FLOAT_EQ(e63.x63()+e63p.x63(),f.x63()) << "e.x63()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder63e63adde63p){
+
+    TestData td;
+    const auto & e63 = td.e63;
+    const auto & e63p = td.e63p;
+    mandel6x3 f;
+    f = e63p + e63;
+
+    EXPECT_FLOAT_EQ(e63.x11()+e63p.x11(),f.x11()) << "e.x11()";
+    EXPECT_FLOAT_EQ(e63.x12()+e63p.x12(),f.x12()) << "e.x12()";
+    EXPECT_FLOAT_EQ(e63.x13()+e63p.x13(),f.x13()) << "e.x13()";
+    EXPECT_FLOAT_EQ(e63.x21()+e63p.x21(),f.x21()) << "e.x21()";
+    EXPECT_FLOAT_EQ(e63.x22()+e63p.x22(),f.x22()) << "e.x22()";
+    EXPECT_FLOAT_EQ(e63.x23()+e63p.x23(),f.x23()) << "e.x23()";
+    EXPECT_FLOAT_EQ(e63.x31()+e63p.x31(),f.x31()) << "e.x31()";
+    EXPECT_FLOAT_EQ(e63.x32()+e63p.x32(),f.x32()) << "e.x32()";
+    EXPECT_FLOAT_EQ(e63.x33()+e63p.x33(),f.x33()) << "e.x33()";
+    EXPECT_FLOAT_EQ(e63.x41()+e63p.x41(),f.x41()) << "e.x41()";
+    EXPECT_FLOAT_EQ(e63.x42()+e63p.x42(),f.x42()) << "e.x42()";
+    EXPECT_FLOAT_EQ(e63.x43()+e63p.x43(),f.x43()) << "e.x43()";
+    EXPECT_FLOAT_EQ(e63.x51()+e63p.x51(),f.x51()) << "e.x51()";
+    EXPECT_FLOAT_EQ(e63.x52()+e63p.x52(),f.x52()) << "e.x52()";
+    EXPECT_FLOAT_EQ(e63.x53()+e63p.x53(),f.x53()) << "e.x53()";
+    EXPECT_FLOAT_EQ(e63.x61()+e63p.x61(),f.x61()) << "e.x61()";
+    EXPECT_FLOAT_EQ(e63.x62()+e63p.x62(),f.x62()) << "e.x62()";
+    EXPECT_FLOAT_EQ(e63.x63()+e63p.x63(),f.x63()) << "e.x63()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder63e63minuse63p){
+
+    TestData td;
+    const auto & e63 = td.e63;
+    const auto & e63p = td.e63p;
+    mandel6x3 f;
+    f = e63 - e63p;
+
+    EXPECT_FLOAT_EQ(e63.x11()-e63p.x11(),f.x11()) << "e.x11()";
+    EXPECT_FLOAT_EQ(e63.x12()-e63p.x12(),f.x12()) << "e.x12()";
+    EXPECT_FLOAT_EQ(e63.x13()-e63p.x13(),f.x13()) << "e.x13()";
+    EXPECT_FLOAT_EQ(e63.x21()-e63p.x21(),f.x21()) << "e.x21()";
+    EXPECT_FLOAT_EQ(e63.x22()-e63p.x22(),f.x22()) << "e.x22()";
+    EXPECT_FLOAT_EQ(e63.x23()-e63p.x23(),f.x23()) << "e.x23()";
+    EXPECT_FLOAT_EQ(e63.x31()-e63p.x31(),f.x31()) << "e.x31()";
+    EXPECT_FLOAT_EQ(e63.x32()-e63p.x32(),f.x32()) << "e.x32()";
+    EXPECT_FLOAT_EQ(e63.x33()-e63p.x33(),f.x33()) << "e.x33()";
+    EXPECT_FLOAT_EQ(e63.x41()-e63p.x41(),f.x41()) << "e.x41()";
+    EXPECT_FLOAT_EQ(e63.x42()-e63p.x42(),f.x42()) << "e.x42()";
+    EXPECT_FLOAT_EQ(e63.x43()-e63p.x43(),f.x43()) << "e.x43()";
+    EXPECT_FLOAT_EQ(e63.x51()-e63p.x51(),f.x51()) << "e.x51()";
+    EXPECT_FLOAT_EQ(e63.x52()-e63p.x52(),f.x52()) << "e.x52()";
+    EXPECT_FLOAT_EQ(e63.x53()-e63p.x53(),f.x53()) << "e.x53()";
+    EXPECT_FLOAT_EQ(e63.x61()-e63p.x61(),f.x61()) << "e.x61()";
+    EXPECT_FLOAT_EQ(e63.x62()-e63p.x62(),f.x62()) << "e.x62()";
+    EXPECT_FLOAT_EQ(e63.x63()-e63p.x63(),f.x63()) << "e.x63()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder63e63xReal){
+
+    TestData td;
+    const auto & e63 = td.e63;
+    const auto & r1 = td.r1;
+    mandel6x3 f = e63;
+    f*=r1;
+
+    EXPECT_FLOAT_EQ(e63.x11()*r1,f.x11()) << "e.x11()";
+    EXPECT_FLOAT_EQ(e63.x12()*r1,f.x12()) << "e.x12()";
+    EXPECT_FLOAT_EQ(e63.x13()*r1,f.x13()) << "e.x13()";
+    EXPECT_FLOAT_EQ(e63.x21()*r1,f.x21()) << "e.x21()";
+    EXPECT_FLOAT_EQ(e63.x22()*r1,f.x22()) << "e.x22()";
+    EXPECT_FLOAT_EQ(e63.x23()*r1,f.x23()) << "e.x23()";
+    EXPECT_FLOAT_EQ(e63.x31()*r1,f.x31()) << "e.x31()";
+    EXPECT_FLOAT_EQ(e63.x32()*r1,f.x32()) << "e.x32()";
+    EXPECT_FLOAT_EQ(e63.x33()*r1,f.x33()) << "e.x33()";
+    EXPECT_FLOAT_EQ(e63.x41()*r1,f.x41()) << "e.x41()";
+    EXPECT_FLOAT_EQ(e63.x42()*r1,f.x42()) << "e.x42()";
+    EXPECT_FLOAT_EQ(e63.x43()*r1,f.x43()) << "e.x43()";
+    EXPECT_FLOAT_EQ(e63.x51()*r1,f.x51()) << "e.x51()";
+    EXPECT_FLOAT_EQ(e63.x52()*r1,f.x52()) << "e.x52()";
+    EXPECT_FLOAT_EQ(e63.x53()*r1,f.x53()) << "e.x53()";
+    EXPECT_FLOAT_EQ(e63.x61()*r1,f.x61()) << "e.x61()";
+    EXPECT_FLOAT_EQ(e63.x62()*r1,f.x62()) << "e.x62()";
+    EXPECT_FLOAT_EQ(e63.x63()*r1,f.x63()) << "e.x63()";
+}
+
+TEST(mandel_tensors,Basic3rdOrderBinary63e63xReal){
+
+    TestData td;
+    const auto & e63 = td.e63;
+    const auto & r1 = td.r1;
+    mandel6x3 f;
+    f= e63*r1;
+
+    EXPECT_FLOAT_EQ(e63.x11()*r1,f.x11()) << "e.x11()";
+    EXPECT_FLOAT_EQ(e63.x12()*r1,f.x12()) << "e.x12()";
+    EXPECT_FLOAT_EQ(e63.x13()*r1,f.x13()) << "e.x13()";
+    EXPECT_FLOAT_EQ(e63.x21()*r1,f.x21()) << "e.x21()";
+    EXPECT_FLOAT_EQ(e63.x22()*r1,f.x22()) << "e.x22()";
+    EXPECT_FLOAT_EQ(e63.x23()*r1,f.x23()) << "e.x23()";
+    EXPECT_FLOAT_EQ(e63.x31()*r1,f.x31()) << "e.x31()";
+    EXPECT_FLOAT_EQ(e63.x32()*r1,f.x32()) << "e.x32()";
+    EXPECT_FLOAT_EQ(e63.x33()*r1,f.x33()) << "e.x33()";
+    EXPECT_FLOAT_EQ(e63.x41()*r1,f.x41()) << "e.x41()";
+    EXPECT_FLOAT_EQ(e63.x42()*r1,f.x42()) << "e.x42()";
+    EXPECT_FLOAT_EQ(e63.x43()*r1,f.x43()) << "e.x43()";
+    EXPECT_FLOAT_EQ(e63.x51()*r1,f.x51()) << "e.x51()";
+    EXPECT_FLOAT_EQ(e63.x52()*r1,f.x52()) << "e.x52()";
+    EXPECT_FLOAT_EQ(e63.x53()*r1,f.x53()) << "e.x53()";
+    EXPECT_FLOAT_EQ(e63.x61()*r1,f.x61()) << "e.x61()";
+    EXPECT_FLOAT_EQ(e63.x62()*r1,f.x62()) << "e.x62()";
+    EXPECT_FLOAT_EQ(e63.x63()*r1,f.x63()) << "e.x63()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder63BinaryRealxe63){
+
+    TestData td;
+    const auto & e63 = td.e63;
+    const auto & r1 = td.r1;
+    mandel6x3 f;
+    f = r1*e63;
+
+    EXPECT_FLOAT_EQ(e63.x11()*r1,f.x11()) << "e.x11()";
+    EXPECT_FLOAT_EQ(e63.x12()*r1,f.x12()) << "e.x12()";
+    EXPECT_FLOAT_EQ(e63.x13()*r1,f.x13()) << "e.x13()";
+    EXPECT_FLOAT_EQ(e63.x21()*r1,f.x21()) << "e.x21()";
+    EXPECT_FLOAT_EQ(e63.x22()*r1,f.x22()) << "e.x22()";
+    EXPECT_FLOAT_EQ(e63.x23()*r1,f.x23()) << "e.x23()";
+    EXPECT_FLOAT_EQ(e63.x31()*r1,f.x31()) << "e.x31()";
+    EXPECT_FLOAT_EQ(e63.x32()*r1,f.x32()) << "e.x32()";
+    EXPECT_FLOAT_EQ(e63.x33()*r1,f.x33()) << "e.x33()";
+    EXPECT_FLOAT_EQ(e63.x41()*r1,f.x41()) << "e.x41()";
+    EXPECT_FLOAT_EQ(e63.x42()*r1,f.x42()) << "e.x42()";
+    EXPECT_FLOAT_EQ(e63.x43()*r1,f.x43()) << "e.x43()";
+    EXPECT_FLOAT_EQ(e63.x51()*r1,f.x51()) << "e.x51()";
+    EXPECT_FLOAT_EQ(e63.x52()*r1,f.x52()) << "e.x52()";
+    EXPECT_FLOAT_EQ(e63.x53()*r1,f.x53()) << "e.x53()";
+    EXPECT_FLOAT_EQ(e63.x61()*r1,f.x61()) << "e.x61()";
+    EXPECT_FLOAT_EQ(e63.x62()*r1,f.x62()) << "e.x62()";
+    EXPECT_FLOAT_EQ(e63.x63()*r1,f.x63()) << "e.x63()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder63e63divReal){
+
+    TestData td;
+    const auto & e63 = td.e63;
+    const auto & r1 = td.r1;
+    mandel6x3 f = e63;
+    f/=r1;
+
+    EXPECT_FLOAT_EQ(e63.x11()/r1,f.x11()) << "e.x11()";
+    EXPECT_FLOAT_EQ(e63.x12()/r1,f.x12()) << "e.x12()";
+    EXPECT_FLOAT_EQ(e63.x13()/r1,f.x13()) << "e.x13()";
+    EXPECT_FLOAT_EQ(e63.x21()/r1,f.x21()) << "e.x21()";
+    EXPECT_FLOAT_EQ(e63.x22()/r1,f.x22()) << "e.x22()";
+    EXPECT_FLOAT_EQ(e63.x23()/r1,f.x23()) << "e.x23()";
+    EXPECT_FLOAT_EQ(e63.x31()/r1,f.x31()) << "e.x31()";
+    EXPECT_FLOAT_EQ(e63.x32()/r1,f.x32()) << "e.x32()";
+    EXPECT_FLOAT_EQ(e63.x33()/r1,f.x33()) << "e.x33()";
+    EXPECT_FLOAT_EQ(e63.x41()/r1,f.x41()) << "e.x41()";
+    EXPECT_FLOAT_EQ(e63.x42()/r1,f.x42()) << "e.x42()";
+    EXPECT_FLOAT_EQ(e63.x43()/r1,f.x43()) << "e.x43()";
+    EXPECT_FLOAT_EQ(e63.x51()/r1,f.x51()) << "e.x51()";
+    EXPECT_FLOAT_EQ(e63.x52()/r1,f.x52()) << "e.x52()";
+    EXPECT_FLOAT_EQ(e63.x53()/r1,f.x53()) << "e.x53()";
+    EXPECT_FLOAT_EQ(e63.x61()/r1,f.x61()) << "e.x61()";
+    EXPECT_FLOAT_EQ(e63.x62()/r1,f.x62()) << "e.x62()";
+    EXPECT_FLOAT_EQ(e63.x63()/r1,f.x63()) << "e.x63()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder63Binarye63divReal){
+
+    TestData td;
+    const auto & e63 = td.e63;
+    const auto & r1 = td.r1;
+    mandel6x3 f;
+    f = e63/r1;
+
+    EXPECT_FLOAT_EQ(e63.x11()/r1,f.x11()) << "e.x11()";
+    EXPECT_FLOAT_EQ(e63.x12()/r1,f.x12()) << "e.x12()";
+    EXPECT_FLOAT_EQ(e63.x13()/r1,f.x13()) << "e.x13()";
+    EXPECT_FLOAT_EQ(e63.x21()/r1,f.x21()) << "e.x21()";
+    EXPECT_FLOAT_EQ(e63.x22()/r1,f.x22()) << "e.x22()";
+    EXPECT_FLOAT_EQ(e63.x23()/r1,f.x23()) << "e.x23()";
+    EXPECT_FLOAT_EQ(e63.x31()/r1,f.x31()) << "e.x31()";
+    EXPECT_FLOAT_EQ(e63.x32()/r1,f.x32()) << "e.x32()";
+    EXPECT_FLOAT_EQ(e63.x33()/r1,f.x33()) << "e.x33()";
+    EXPECT_FLOAT_EQ(e63.x41()/r1,f.x41()) << "e.x41()";
+    EXPECT_FLOAT_EQ(e63.x42()/r1,f.x42()) << "e.x42()";
+    EXPECT_FLOAT_EQ(e63.x43()/r1,f.x43()) << "e.x43()";
+    EXPECT_FLOAT_EQ(e63.x51()/r1,f.x51()) << "e.x51()";
+    EXPECT_FLOAT_EQ(e63.x52()/r1,f.x52()) << "e.x52()";
+    EXPECT_FLOAT_EQ(e63.x53()/r1,f.x53()) << "e.x53()";
+    EXPECT_FLOAT_EQ(e63.x61()/r1,f.x61()) << "e.x61()";
+    EXPECT_FLOAT_EQ(e63.x62()/r1,f.x62()) << "e.x62()";
+    EXPECT_FLOAT_EQ(e63.x63()/r1,f.x63()) << "e.x63()";
+}
+
+TEST(mandel_tensors,Basic3rdOrder63e63minuseqe63p){
+
+    TestData td;
+    const auto & e63 = td.e63;
+    const auto & e63p = td.e63p;
+    mandel6x3 f=e63;
+    f-=e63p;
+
+    EXPECT_FLOAT_EQ(e63.x11()-e63p.x11(),f.x11()) << "e.x11()";
+    EXPECT_FLOAT_EQ(e63.x12()-e63p.x12(),f.x12()) << "e.x12()";
+    EXPECT_FLOAT_EQ(e63.x13()-e63p.x13(),f.x13()) << "e.x13()";
+    EXPECT_FLOAT_EQ(e63.x21()-e63p.x21(),f.x21()) << "e.x21()";
+    EXPECT_FLOAT_EQ(e63.x22()-e63p.x22(),f.x22()) << "e.x22()";
+    EXPECT_FLOAT_EQ(e63.x23()-e63p.x23(),f.x23()) << "e.x23()";
+    EXPECT_FLOAT_EQ(e63.x31()-e63p.x31(),f.x31()) << "e.x31()";
+    EXPECT_FLOAT_EQ(e63.x32()-e63p.x32(),f.x32()) << "e.x32()";
+    EXPECT_FLOAT_EQ(e63.x33()-e63p.x33(),f.x33()) << "e.x33()";
+    EXPECT_FLOAT_EQ(e63.x41()-e63p.x41(),f.x41()) << "e.x41()";
+    EXPECT_FLOAT_EQ(e63.x42()-e63p.x42(),f.x42()) << "e.x42()";
+    EXPECT_FLOAT_EQ(e63.x43()-e63p.x43(),f.x43()) << "e.x43()";
+    EXPECT_FLOAT_EQ(e63.x51()-e63p.x51(),f.x51()) << "e.x51()";
+    EXPECT_FLOAT_EQ(e63.x52()-e63p.x52(),f.x52()) << "e.x52()";
+    EXPECT_FLOAT_EQ(e63.x53()-e63p.x53(),f.x53()) << "e.x53()";
+    EXPECT_FLOAT_EQ(e63.x61()-e63p.x61(),f.x61()) << "e.x61()";
+    EXPECT_FLOAT_EQ(e63.x62()-e63p.x62(),f.x62()) << "e.x62()";
+    EXPECT_FLOAT_EQ(e63.x63()-e63p.x63(),f.x63()) << "e.x63()";
+}
+
+/*************************************************************************
+ * Linear Algebra Tests for 3rd order Tensor (MandelTensor63)
+ ************************************************************************/
+TEST(mandel_tensors,LinAlg3rdOrder63Transposee63){
+
+    TestData td;
+    const auto & e63 = td.e63;
+    mandel3x6 f = Transpose(e63);
+
+    EXPECT_FLOAT_EQ(e63.x11(),f.x11()) << "e.x11()";
+    EXPECT_FLOAT_EQ(e63.x21(),f.x12()) << "e.x12()";
+    EXPECT_FLOAT_EQ(e63.x31(),f.x13()) << "e.x13()";
+    EXPECT_FLOAT_EQ(e63.x41(),f.x14()) << "e.x14()";
+    EXPECT_FLOAT_EQ(e63.x51(),f.x15()) << "e.x15()";
+    EXPECT_FLOAT_EQ(e63.x61(),f.x16()) << "e.x16()";
+    EXPECT_FLOAT_EQ(e63.x12(),f.x21()) << "e.x21()";
+    EXPECT_FLOAT_EQ(e63.x22(),f.x22()) << "e.x22()";
+    EXPECT_FLOAT_EQ(e63.x32(),f.x23()) << "e.x23()";
+    EXPECT_FLOAT_EQ(e63.x42(),f.x24()) << "e.x24()";
+    EXPECT_FLOAT_EQ(e63.x52(),f.x25()) << "e.x25()";
+    EXPECT_FLOAT_EQ(e63.x62(),f.x26()) << "e.x26()";
+    EXPECT_FLOAT_EQ(e63.x13(),f.x31()) << "e.x31()";
+    EXPECT_FLOAT_EQ(e63.x23(),f.x32()) << "e.x32()";
+    EXPECT_FLOAT_EQ(e63.x33(),f.x33()) << "e.x33()";
+    EXPECT_FLOAT_EQ(e63.x43(),f.x34()) << "e.x34()";
+    EXPECT_FLOAT_EQ(e63.x53(),f.x35()) << "e.x35()";
+    EXPECT_FLOAT_EQ(e63.x63(),f.x36()) << "e.x36()";
+}
+
+TEST(mandel_tensors,LinAlg3rdOrder63Cxe63){
+
+    TestData td;
+    mandel6x3 f = td.C*td.e63;
+
+    EXPECT_FLOAT_EQ(1.7583802475541608,f.x11()) << "e.x11()";
+    EXPECT_FLOAT_EQ(1.6477108574850361,f.x12()) << "e.x12()";
+    EXPECT_FLOAT_EQ(1.5945079123658290,f.x13()) << "e.x13()";
+    EXPECT_FLOAT_EQ(1.5006121644806141,f.x21()) << "e.x21()";
+    EXPECT_FLOAT_EQ(1.4573393031354889,f.x22()) << "e.x22()";
+    EXPECT_FLOAT_EQ(1.5407967086859855,f.x23()) << "e.x23()";
+    EXPECT_FLOAT_EQ(1.6098213949562987,f.x31()) << "e.x31()";
+    EXPECT_FLOAT_EQ(0.7956299846332452,f.x32()) << "e.x32()";
+    EXPECT_FLOAT_EQ(0.9513912394229351,f.x33()) << "e.x33()";
+    EXPECT_FLOAT_EQ(2.0476653342536513,f.x41()) << "e.x41()";
+    EXPECT_FLOAT_EQ(0.9335047788801307,f.x42()) << "e.x42()";
+    EXPECT_FLOAT_EQ(1.0975390055553489,f.x43()) << "e.x43()";
+    EXPECT_FLOAT_EQ(3.0519768882895737,f.x51()) << "e.x51()";
+    EXPECT_FLOAT_EQ(1.9588761419308951,f.x52()) << "e.x52()";
+    EXPECT_FLOAT_EQ(2.5463107147298092,f.x53()) << "e.x53()";
+    EXPECT_FLOAT_EQ(1.9996090051011508,f.x61()) << "e.x61()";
+    EXPECT_FLOAT_EQ(1.1079031185693664,f.x62()) << "e.x62()";
+    EXPECT_FLOAT_EQ(1.4976255324092389,f.x63()) << "e.x63()";
+}
+
+TEST(mandel_tensors,LinAlg3rdOrder63e63xTensorV){
+
+    TestData td;
+    mandel6x3 f = td.e63*td.TV;
+
+    EXPECT_FLOAT_EQ(0.8906847120906268,f.x11()) << "e.x11()";
+    EXPECT_FLOAT_EQ(0.9270169652403459,f.x12()) << "e.x12()";
+    EXPECT_FLOAT_EQ(1.1081099064471629,f.x13()) << "e.x13()";
+    EXPECT_FLOAT_EQ(0.4184921249677286,f.x21()) << "e.x21()";
+    EXPECT_FLOAT_EQ(1.1558347277735985,f.x22()) << "e.x22()";
+    EXPECT_FLOAT_EQ(0.4153324072539976,f.x23()) << "e.x23()";
+    EXPECT_FLOAT_EQ(0.4573911817523391,f.x31()) << "e.x31()";
+    EXPECT_FLOAT_EQ(0.6956508580416848,f.x32()) << "e.x32()";
+    EXPECT_FLOAT_EQ(0.2819785203466282,f.x33()) << "e.x33()";
+    EXPECT_FLOAT_EQ(0.2662789282452787,f.x41()) << "e.x41()";
+    EXPECT_FLOAT_EQ(0.6844967313795165,f.x42()) << "e.x42()";
+    EXPECT_FLOAT_EQ(0.3486545551228658,f.x43()) << "e.x43()";
+    EXPECT_FLOAT_EQ(0.5495077493692450,f.x51()) << "e.x51()";
+    EXPECT_FLOAT_EQ(1.0201726332039649,f.x52()) << "e.x52()";
+    EXPECT_FLOAT_EQ(0.9132822350759278,f.x53()) << "e.x53()";
+    EXPECT_FLOAT_EQ(0.3286483672357691,f.x61()) << "e.x61()";
+    EXPECT_FLOAT_EQ(0.4433849126439117,f.x62()) << "e.x62()";
+    EXPECT_FLOAT_EQ(0.4539125712913405,f.x63()) << "e.x63()";
+}
+
+TEST(mandel_tensors,LinAlg3rdOrder63e63xV6){
+
+    TestData td;
+    mandel6x3 f = td.e63*td.V;
+
+    EXPECT_FLOAT_EQ(0.8906847120906268,f.x11()) << "e.x11()";
+    EXPECT_FLOAT_EQ(0.9270169652403459,f.x12()) << "e.x12()";
+    EXPECT_FLOAT_EQ(1.1081099064471629,f.x13()) << "e.x13()";
+    EXPECT_FLOAT_EQ(0.4184921249677286,f.x21()) << "e.x21()";
+    EXPECT_FLOAT_EQ(1.1558347277735985,f.x22()) << "e.x22()";
+    EXPECT_FLOAT_EQ(0.4153324072539976,f.x23()) << "e.x23()";
+    EXPECT_FLOAT_EQ(0.4573911817523391,f.x31()) << "e.x31()";
+    EXPECT_FLOAT_EQ(0.6956508580416848,f.x32()) << "e.x32()";
+    EXPECT_FLOAT_EQ(0.2819785203466282,f.x33()) << "e.x33()";
+    EXPECT_FLOAT_EQ(0.2662789282452787,f.x41()) << "e.x41()";
+    EXPECT_FLOAT_EQ(0.6844967313795165,f.x42()) << "e.x42()";
+    EXPECT_FLOAT_EQ(0.3486545551228658,f.x43()) << "e.x43()";
+    EXPECT_FLOAT_EQ(0.5495077493692450,f.x51()) << "e.x51()";
+    EXPECT_FLOAT_EQ(1.0201726332039649,f.x52()) << "e.x52()";
+    EXPECT_FLOAT_EQ(0.9132822350759278,f.x53()) << "e.x53()";
+    EXPECT_FLOAT_EQ(0.3286483672357691,f.x61()) << "e.x61()";
+    EXPECT_FLOAT_EQ(0.4433849126439117,f.x62()) << "e.x62()";
+    EXPECT_FLOAT_EQ(0.4539125712913405,f.x63()) << "e.x63()";
 }

--- a/p3a_unit_tests.cpp
+++ b/p3a_unit_tests.cpp
@@ -40,7 +40,7 @@ using namespace p3a;
 
 using Y = double;
 
-Y abs_err = epsilon_value<Y>();
+Y abs_err = Y(5.)*epsilon_value<Y>();
 
 struct TestData {
 
@@ -160,43 +160,43 @@ struct TestData {
         TVstatic(2,0)=0.0040298826046717; 
         TVstatic(2,1)=0.9667841040427785;
         TVstatic(2,2)=0.6018325296947370;
-
-        Cstatic(0,0)=0.4335153608215544; 
+        
+        Cstatic(0,0)=0.4335153608215544;
         Cstatic(0,1)=0.0856007508096491;
-        Cstatic(0,2)=0.6181864586228960, 
-        Cstatic(0,3)=1.0180326366236518, 
-        Cstatic(0,4)=0.9998149495390550, 
-        Cstatic(0,5)=1.3248978263217353,
+        Cstatic(0,2)=0.6181864586228960; 
+        Cstatic(0,3)=0.7198577808258045;
+        Cstatic(0,4)=0.7069759307507516; 
+        Cstatic(0,5)=0.9368442373714156; 
         Cstatic(1,0)=0.4327952022077987; 
-        Cstatic(1,1)=0.3742135173559312;
-        Cstatic(1,2)=0.1080020759711545;
-        Cstatic(1,3)=0.8147725263605445;
-        Cstatic(1,4)=0.9048931279343728;
-        Cstatic(1,5)=1.2476465544083184;
-        Cstatic(2,0)=0.1619267043337781; 
+        Cstatic(1,1)=0.3742135173559312; 
+        Cstatic(1,2)=0.1080020759711545; 
+        Cstatic(1,3)=0.5761311785140361; 
+        Cstatic(1,4)=0.6398560670115011; 
+        Cstatic(1,5)=0.8822193391461527;
+        Cstatic(2,0)=0.1619267043337781;
         Cstatic(2,1)=0.8255468602509465; 
         Cstatic(2,2)=0.4823784238849611; 
-        Cstatic(2,3)=0.6837503075397613; 
-        Cstatic(2,4)=0.0784973317433504; 
-        Cstatic(2,5)=0.8368479998334433;
-        Cstatic(3,0)=0.0112200396694362; 
-        Cstatic(3,1)=0.8194354458300377; 
-        Cstatic(3,2)=1.1074040005476036; 
-        Cstatic(3,3)=0.6118023983888154; 
-        Cstatic(3,4)=0.4369542629777867; 
-        Cstatic(3,5)=0.6474343145633832;
-        Cstatic(4,0)=0.0836906759361557; 
-        Cstatic(4,1)=0.9338502039452401; 
-        Cstatic(4,2)=0.9911298229891556; 
-        Cstatic(4,3)=1.6059479559586896; 
-        Cstatic(4,4)=1.9166663623233735; 
-        Cstatic(4,5)=0.8109702524757447;
-        Cstatic(5,0)=0.0501618784358511;
-        Cstatic(5,1)=0.9139519661627958; 
-        Cstatic(5,2)=0.4597365381087316;
-        Cstatic(5,3)=1.0569116390136390;
-        Cstatic(5,4)=0.6655431451182421;
-        Cstatic(5,5)=0.9678972164817718;
+        Cstatic(2,3)=0.4834844790997526; 
+        Cstatic(2,4)=0.0555059955807731; 
+        Cstatic(2,5)=0.5917408955046265;
+        Cstatic(3,0)=0.0079337661354404; 
+        Cstatic(3,1)=0.5794283604910414; 
+        Cstatic(3,2)=0.7830528783003216; 
+        Cstatic(3,3)=0.3059011991944077; 
+        Cstatic(3,4)=0.2184771314888934; 
+        Cstatic(3,5)=0.3237171572816916;
+        Cstatic(4,0)=0.0591782444765415; 
+        Cstatic(4,1)=0.6603318118221196; 
+        Cstatic(4,2)=0.7008346188718544; 
+        Cstatic(4,3)=0.8029739779793448; 
+        Cstatic(4,4)=0.9583331811616868; 
+        Cstatic(4,5)=0.4054851262378724;
+        Cstatic(5,0)=0.0354698043990456;
+        Cstatic(5,1)=0.6462616329524909; 
+        Cstatic(5,2)=0.3250828236559117; 
+        Cstatic(5,3)=0.5284558195068195; 
+        Cstatic(5,4)=0.3327715725591210; 
+        Cstatic(5,5)=0.4839486082408859;
     }
 };
 
@@ -210,11 +210,8 @@ TEST(mandel_tensors,LinAlg2ndOrderMandelVectorInverseV){
     const auto & V = td.V;
     const auto & ident = td.ident;
     mandel6x1 T = inverse(V);
-    //better comparison is to make sure it is identity tensor
-    mandel6x1 I = mandel6x1<Y>::identity();
-
-    I = V*T;
-
+    mandel6x1 I = T*V;
+    
     EXPECT_NEAR(ident.x1(),I.x1(),abs_err) << "I.x1";
     EXPECT_NEAR(ident.x2(),I.x2(),abs_err) << "I.x2";
     EXPECT_NEAR(ident.x3(),I.x3(),abs_err) << "I.x3";
@@ -232,6 +229,7 @@ TEST(mandel_tensors,LinAlg4thOrderMandelTensorInverseC){
 
     mandel6x6 Ct = C;
     Ct.MandelXform();
+
     mandel6x6 St = inverse(Ct);
     St.invMandelXform();
     mandel6x6 S = C*St;
@@ -297,7 +295,7 @@ TEST(mandel_tensors,Construct2ndOrderVfromMatrix3x3Vxform){
     TestData td;
     const auto & V = td.V;
     const auto & TV = td.TV;
-    mandel6x1 Vt= TV;
+    mandel6x1 Vt = TV;
 
     EXPECT_FLOAT_EQ(V.x1(),Vt.x1()) << "V.x1";
     EXPECT_FLOAT_EQ(V.x2(),Vt.x2()) << "V.x2";
@@ -2297,3 +2295,4 @@ TEST(mandel_tensors,LinAlg3rdOrder63e63xV6){
     EXPECT_FLOAT_EQ(0.4433849126439117,f.x62()) << "e.x62()";
     EXPECT_FLOAT_EQ(0.4539125712913405,f.x63()) << "e.x63()";
 }
+


### PR DESCRIPTION
Symmetric Tensor (Voigt-Mandel) Math Library
============================================
Scope of the Library
----------------------------------
This set of classes and functions allows for linear algebra to be performed
in the context of material models. This package enables the usual linear
algebra operations with symmetric 1x6, 6x1, 6x6, 6x3, and 3x6 tensors and 
is able to perform mixed operations with the `diagonal3x3`, `symmetric3x3` 
and `matrix3x3` classes also avaliable in P3A.  operations are carried out 
component by component, elimininating the need for arrays and permitting 
functions to be _inline_ consistent with the performance requirements of
P3A. 
This header provides the class: 
- `mandel6x1` (6x1) 2nd order Tensor
  
  Constructors:
  
  - `mandel6x1(mandel6x1)`
  - `mandel6x1(<list of values>)`
  - `mandel6x1(symmetric3x3)`
  - `mandel6x1(matrix3x3)` -- includes testing for symmetry
  - `mandel6x1(static_matrix3x3)` -- includes testing for symmetry
Other `mandelNxN` headers provide the classes:
- `mandel6x6` (6x6) 4th order Tensor
- `mandel3x6` (3x6) 3rd order Tensor
- `mandel6x3` (6x3) 3rd order Tensor
Mandel Notation and Voigt Notation
----------------------------------
The primary addition of this library is the ability to perform the usual
linear algebra relations with normal Tensors and Vectors along with symmetric 
ones often found in mechanics. This package uses *Mandel* notation, not 
_Voigt_ notation. Mandel notation is simmilar to Voigt's notation in that
symmetric 2<sup>nd</sup>-order tensors are represented by 6x1 vectors, and 
4<sup>th</sup>-order tensors are represented by 6x6 tensors. Mandel notation 
is applied to all tensors/vectors unlike Voigt notation. 
Mandel notation allows for all standard linear algebra operations to be
correctly normalized and eliminates the need for strain, or stress-like Voigt
tensors (symmetric strain-like tensors will have of 2 in front of off-diagonal 
components, while stress like tensors will have a factor of 1). Converting 
to Mandel notation (which properly normalizes the tensor) will ease computations
with operations produce vectors (3x1) or full (3x3) 2<sup>nd</sup>-order tensors.
Mandel Transformation is applied internally upon construction of a Mandel-type 
object which includes all of the symmetric Mandel Tensor types (6x1, 6x6, 3x6, 
or 6x3). Avaliable constructors vary by mandel tensor type, so see notes in each
specific header. By default, all constructors apply the Mandel Transform, but it can be 
overridden by specifying a Boolean `false` value to the end of the constructor 
argument list. Note that, if you use the `zero()` or `identity()` constructor, 
you will have a tensor that won't carry the transform to further operations, the 
transformation must be applied manually by applying the method `MandelXform()` 
method to the Mandel-type object. The transform will be contained in any result 
returning a Mandel-type object. This means that the Mandel transformation must be 
inverted when converting mandel6x1 (6-element symmetric tensors) to full 
9-element (3x3) 2<sup>nd</sup>-order tensors. 
This library automatically inverts the Mandel transformation when returning a
member of the `matrix3x3` or `symmetric3x3` classes. Operations that 
return Vectors will not need to be modified (this is why we are using Mandel 
transformations)!  
